### PR TITLE
Multi-threaded systems

### DIFF
--- a/CorgEng.EntityComponentSystem/CorgEng.EntityComponentSystem.csproj
+++ b/CorgEng.EntityComponentSystem/CorgEng.EntityComponentSystem.csproj
@@ -74,6 +74,10 @@
       <Project>{9CCC4A6B-2D13-425D-8C72-B034151EC11C}</Project>
       <Name>CorgEng.Core</Name>
     </ProjectReference>
+    <ProjectReference Include="..\CorgEng.GenericInterfaces\CorgEng.GenericInterfaces.csproj">
+      <Project>{E87F196E-5BF2-4AAF-8209-9F66A4F4B0EB}</Project>
+      <Name>CorgEng.GenericInterfaces</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/CorgEng.EntityComponentSystem/Systems/EntitySystem.cs
+++ b/CorgEng.EntityComponentSystem/Systems/EntitySystem.cs
@@ -1,13 +1,20 @@
-﻿using CorgEng.EntityComponentSystem.Components;
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.EntityComponentSystem.Components;
 using CorgEng.EntityComponentSystem.Entities;
 using CorgEng.EntityComponentSystem.Events;
+using CorgEng.GenericInterfaces.Logging;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 
 namespace CorgEng.EntityComponentSystem.Systems
 {
     public abstract class EntitySystem
     {
+
+        [UsingDependency]
+        private static ILogger Logger;
 
         internal delegate void SystemEventHandlerDelegate(Entity entity, Component component, Event signal);
 
@@ -16,7 +23,43 @@ namespace CorgEng.EntityComponentSystem.Systems
         /// </summary>
         internal static Dictionary<EventComponentPair, List<SystemEventHandlerDelegate>> RegisteredSystemSignalHandlers { get; } = new Dictionary<EventComponentPair, List<SystemEventHandlerDelegate>>();
 
+        private readonly AutoResetEvent waitHandle = new AutoResetEvent(false);
+
+        private readonly ConcurrentQueue<Action> invokationQueue = new ConcurrentQueue<Action>();
+
+        public EntitySystem()
+        {
+            Thread thread = new Thread(SystemThread);
+            thread.Name = $"{this} thread";
+            thread.Start();
+        }
+
         public abstract void SystemSetup();
+
+        private void SystemThread()
+        {
+            //TODO: Make this run until the game is closed
+            while (true)
+            {
+                //Wait until we are awoken again
+                if (invokationQueue.Count == 0)
+                    waitHandle.WaitOne();
+                Action firstInvokation;
+                invokationQueue.TryDequeue(out firstInvokation);
+                if (firstInvokation != null)
+                {
+                    try
+                    {
+                        //Invoke the provided action
+                        firstInvokation.Invoke();
+                    }
+                    catch (Exception e)
+                    {
+                        Logger.WriteLine(e);
+                    }
+                }
+            }
+        }
 
         /// <summary>
         /// Register to a local event
@@ -35,7 +78,10 @@ namespace CorgEng.EntityComponentSystem.Systems
             if (!RegisteredSystemSignalHandlers.ContainsKey(eventComponentPair))
                 RegisteredSystemSignalHandlers.Add(eventComponentPair, new List<SystemEventHandlerDelegate>());
             RegisteredSystemSignalHandlers[eventComponentPair].Add((Entity entity, Component component, Event signal) => {
-                eventHandler.Invoke(entity, (GComponent)component, (GEvent)signal);
+                invokationQueue.Enqueue(() => {
+                    eventHandler.Invoke(entity, (GComponent)component, (GEvent)signal);
+                });
+                waitHandle.Set();
             });
         }
 

--- a/CorgEng.Tests/EntityComponentSystem/SignalTests.cs
+++ b/CorgEng.Tests/EntityComponentSystem/SignalTests.cs
@@ -3,6 +3,8 @@ using CorgEng.EntityComponentSystem.Entities;
 using CorgEng.EntityComponentSystem.Events;
 using CorgEng.EntityComponentSystem.Systems;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Threading;
 
 namespace CorgEng.Tests.EntityComponentSystem
 {
@@ -26,6 +28,7 @@ namespace CorgEng.Tests.EntityComponentSystem
 
         private void HandleTestEvent(Entity entity, TestComponent component, TestEvent eventDetails)
         {
+            Console.WriteLine($"Current thread: {Thread.CurrentThread.Name}");
             SignalTests.handlesReceieved++;
         }
 
@@ -35,11 +38,12 @@ namespace CorgEng.Tests.EntityComponentSystem
     public class SignalTests
     {
 
-        internal static int handlesReceieved = 0;
+        internal volatile static int handlesReceieved = 0;
 
         [TestMethod]
         public void TestSignalHandling()
         {
+            Console.WriteLine($"Current thread: {Thread.CurrentThread.ManagedThreadId}");
             //Setup a test entity system first
             TestEntitySystem entitySystem = new TestEntitySystem();
             entitySystem.SystemSetup();
@@ -52,12 +56,16 @@ namespace CorgEng.Tests.EntityComponentSystem
             Assert.AreEqual(0, handlesReceieved);
             //Send a test signal
             new TestEvent().Raise(testEntity);
+            Thread.Sleep(20);  //Sleep to account for multi-threading
             Assert.AreEqual(1, handlesReceieved);
             new TestEvent().Raise(testEntity);
+            Thread.Sleep(20);  //Sleep to account for multi-threading
             Assert.AreEqual(2, handlesReceieved);
             new OtherEvent().Raise(testEntity);
+            Thread.Sleep(20);  //Sleep to account for multi-threading
             Assert.AreEqual(2, handlesReceieved);
             new TestEvent().Raise(testEntity);
+            Thread.Sleep(20);  //Sleep to account for multi-threading
             Assert.AreEqual(3, handlesReceieved);
         }
 


### PR DESCRIPTION
Systems are now contained within their own thread, will sleep until a method is invoked on them and will wake up to complete their invoked methods.
This should implicitly give us a lot of thread safety, since systems manage their own components so actions against shared reasources will be contained within systems and thus a single thread.