### PR TITLE
Sprite render component & Model fix

### DIFF
--- a/CorgEng.Rendering/Models/SquareModelFactory.cs
+++ b/CorgEng.Rendering/Models/SquareModelFactory.cs
@@ -1,4 +1,5 @@
-﻿using CorgEng.DependencyInjection.Dependencies;
+﻿using CorgEng.Core.Modules;
+using CorgEng.DependencyInjection.Dependencies;
 using CorgEng.GenericInterfaces.Rendering.Models;
 using System;
 using System.Collections.Generic;
@@ -11,6 +12,8 @@ namespace CorgEng.Rendering.Models
     [Dependency(defaultDependency = true)]
     public class SquareModelFactory : ISquareModelFactory
     {
+
+        private static Model model;
 
         private static float[] vertices = {
             0.5f, 0.5f, 0,        //(1, 1)
@@ -30,11 +33,16 @@ namespace CorgEng.Rendering.Models
             1.0f, 1.0f
         };
 
+        [ModuleLoad(mainThread = true)]
+        private static void CreateSquareModel()
+        {
+            model = new Model();
+            model.GenerateBuffers(vertices, uvs);
+        }
+
         public IModel CreateModel()
         {
-            Model createdModel = new Model();
-            createdModel.GenerateBuffers(vertices, uvs);
-            return createdModel;
+            return model;;
         }
 
     }


### PR DESCRIPTION
Fixes models being loaded from non-main threads and adsd in the sprite render component.

![image](https://user-images.githubusercontent.com/26465327/162624078-8cffdde2-75a6-4483-9704-dc27bf24e134.png)

![image](https://user-images.githubusercontent.com/26465327/162624081-c566e0d1-8521-4979-975a-c281006a87e9.png)
