### PR TITLE
Removes uses of AppDomain

### DIFF
--- a/CorgEng.ContentLoading/EntityConfig.cs
+++ b/CorgEng.ContentLoading/EntityConfig.cs
@@ -1,4 +1,5 @@
 ﻿using CorgEng.ContentLoading.XmlDataStructures;
+using CorgEng.Core;
 using CorgEng.GenericInterfaces.ContentLoading;
 using System;
 using System.Collections.Generic;
@@ -24,7 +25,7 @@ namespace CorgEng.ContentLoading
         /// <summary>
         /// A cache of all classes
         /// </summary>
-        public static Dictionary<string, Type> ClassTypeCache = AppDomain.CurrentDomain.GetAssemblies()
+        public static Dictionary<string, Type> ClassTypeCache = CorgEngMain.LoadedAssemblyModules
             .SelectMany(assembly => assembly.GetTypes())
             .Where(type => typeof(IInstantiatable).IsAssignableFrom(type))
             .GroupBy(type => type.Name, StringComparer.OrdinalIgnoreCase)

--- a/CorgEng.Core/CorgEngMain.cs
+++ b/CorgEng.Core/CorgEngMain.cs
@@ -169,7 +169,7 @@ namespace CorgEng.Core
         /// <summary>
         /// An enumerably containing assemblies loaded from the CorgEngConfig.
         /// </summary>
-        private static IEnumerable<Assembly> LoadedAssemblyModules;
+        public static IEnumerable<Assembly> LoadedAssemblyModules;
 
         /// <summary>
         /// Loads a CorgEng config file
@@ -200,6 +200,8 @@ namespace CorgEng.Core
                     {
                         case "DependencyModules":
                             List<Assembly> loadedAssemblies = new List<Assembly>();
+                            loadedAssemblies.Add(Assembly.GetEntryAssembly());
+                            loadedAssemblies.Add(Assembly.GetExecutingAssembly());
                             foreach (XElement dependency in childElement.Elements())
                             {
                                 try
@@ -257,7 +259,7 @@ namespace CorgEng.Core
         /// </summary>
         private static void PriorityModuleInit()
         {
-            ModuleLoadAttributes = AppDomain.CurrentDomain.GetAssemblies()
+            ModuleLoadAttributes = LoadedAssemblyModules
                 .SelectMany(assembly => assembly.GetTypes()
                 .SelectMany(type => type.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
                 .Where(method => method.GetCustomAttribute<ModuleLoadAttribute>() != null )));
@@ -302,7 +304,7 @@ namespace CorgEng.Core
         /// </summary>
         private static void TriggerTerminateMethods()
         {
-            IEnumerable<MethodInfo> TerminateAttributes = AppDomain.CurrentDomain.GetAssemblies()
+            IEnumerable<MethodInfo> TerminateAttributes = LoadedAssemblyModules
                 .SelectMany(assembly => assembly.GetTypes()
                 .SelectMany(type => type.GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
                 .Where(method => method.GetCustomAttribute<ModuleTerminateAttribute>() != null)));

--- a/CorgEng.Core/CorgEngMain.cs
+++ b/CorgEng.Core/CorgEngMain.cs
@@ -200,8 +200,13 @@ namespace CorgEng.Core
                     {
                         case "DependencyModules":
                             List<Assembly> loadedAssemblies = new List<Assembly>();
-                            loadedAssemblies.Add(Assembly.GetEntryAssembly());
-                            loadedAssemblies.Add(Assembly.GetExecutingAssembly());
+                            if (Assembly.GetEntryAssembly() != null)
+                                loadedAssemblies.Add(Assembly.GetEntryAssembly());
+                            //Unit test support.
+                            else if (Assembly.GetCallingAssembly() != null)
+                                loadedAssemblies.Add(Assembly.GetCallingAssembly());
+                            if(Assembly.GetExecutingAssembly() != null)
+                                loadedAssemblies.Add(Assembly.GetExecutingAssembly());
                             foreach (XElement dependency in childElement.Elements())
                             {
                                 try

--- a/CorgEng.Core/Rendering/RenderCore.cs
+++ b/CorgEng.Core/Rendering/RenderCore.cs
@@ -112,7 +112,7 @@ namespace CorgEng.Core.Rendering
                     glBufferData(GL_ARRAY_BUFFER, sizeof(float) * quadVertices.Length, vertexPointer, GL_STATIC_DRAW);
                 }
                 //Create the shaders
-                shaderSet = ShaderFactory?.CreateShaderSet("CoreShader");
+                shaderSet = ShaderFactory.CreateShaderSet("CoreShader");
                 //Get the uniform location of the shaders
                 shaderSet.AttachShaders(programUint);
                 glLinkProgram(programUint);

--- a/CorgEng.EntityComponentSystem/Systems/EntitySystem.cs
+++ b/CorgEng.EntityComponentSystem/Systems/EntitySystem.cs
@@ -97,7 +97,7 @@ namespace CorgEng.EntityComponentSystem.Systems
             Logger?.WriteLine($"Setting up systems...", LogType.LOG);
             //Locate all system types using reflection.
             //Note that we need all systems in all loaded modules
-            IEnumerable<Type> locatedSystems = AppDomain.CurrentDomain.GetAssemblies()
+            IEnumerable<Type> locatedSystems = CorgEngMain.LoadedAssemblyModules
                 .SelectMany(assembly => assembly.GetTypes()
                 .Where(type => typeof(EntitySystem).IsAssignableFrom(type) && !type.IsAbstract));
             Parallel.ForEach(locatedSystems, (type) => {
@@ -214,7 +214,7 @@ namespace CorgEng.EntityComponentSystem.Systems
             //Handle assembly cache
             if (TypeCache == null)
             {
-                TypeCache = AppDomain.CurrentDomain.GetAssemblies()
+                TypeCache = CorgEngMain.LoadedAssemblyModules
                     .SelectMany(assembly => assembly.GetTypes());
             }
             IEnumerable<Type> typesToRegister = TypeCache.Where(type => typeof(GComponent).IsAssignableFrom(type));

--- a/CorgEng.Networking/Components/ComponentExtensions.cs
+++ b/CorgEng.Networking/Components/ComponentExtensions.cs
@@ -1,4 +1,5 @@
-﻿using CorgEng.Core.Dependencies;
+﻿using CorgEng.Core;
+using CorgEng.Core.Dependencies;
 using CorgEng.Core.Modules;
 using CorgEng.EntityComponentSystem.Components;
 using CorgEng.GenericInterfaces.Logging;
@@ -45,7 +46,7 @@ namespace CorgEng.Networking.Components
             Stopwatch stopwatch = Stopwatch.StartNew();
             Logger?.WriteLine($"Loading Networking Component Extensions...", LogType.LOG);
             //Locate all component types
-            IEnumerable<Type> locatedComponentTypes = AppDomain.CurrentDomain.GetAssemblies()
+            IEnumerable<Type> locatedComponentTypes = CorgEngMain.LoadedAssemblyModules
                 .SelectMany(x => x.GetTypes())
                 .Where(type => typeof(Component).IsAssignableFrom(type) && !type.IsAbstract);
             //Populate the property info cache

--- a/CorgEng.Networking/VersionSync/VersionGenerator.cs
+++ b/CorgEng.Networking/VersionSync/VersionGenerator.cs
@@ -1,4 +1,5 @@
-﻿using CorgEng.Core.Dependencies;
+﻿using CorgEng.Core;
+using CorgEng.Core.Dependencies;
 using CorgEng.Core.Modules;
 using CorgEng.EntityComponentSystem.Components;
 using CorgEng.EntityComponentSystem.Events;
@@ -39,7 +40,7 @@ namespace CorgEng.Networking.VersionSync
             //Use reflection to collect all event types
             //Sort the types alphabetically (They need to be sorted to be deterministic)
             IVersionSynced e;
-            IOrderedEnumerable<Type> LocatedTypes = AppDomain.CurrentDomain.GetAssemblies()
+            IOrderedEnumerable<Type> LocatedTypes = CorgEngMain.LoadedAssemblyModules
                 .SelectMany(assembly => assembly.GetTypes()
                 .Where(t => !t.IsAbstract &&
                         typeof(IVersionSynced).IsAssignableFrom(t)

--- a/CorgEng.Tests/NetworkingTests/SerializationTest.cs
+++ b/CorgEng.Tests/NetworkingTests/SerializationTest.cs
@@ -1,4 +1,5 @@
-﻿using CorgEng.Core.Dependencies;
+﻿using CorgEng.Core;
+using CorgEng.Core.Dependencies;
 using CorgEng.EntityComponentSystem.Components;
 using CorgEng.EntityComponentSystem.Events;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
@@ -31,7 +32,7 @@ namespace CorgEng.Tests.NetworkingTests
             //Give it a seed, so tests are repeatable
             Random random = new Random(0);
             //Get all component classes
-            IEnumerable<Type> components = AppDomain.CurrentDomain.GetAssemblies()
+            IEnumerable<Type> components = CorgEngMain.LoadedAssemblyModules
                 .SelectMany(assembly => assembly.GetTypes()
                 .Where(type => typeof(Component).IsAssignableFrom(type)));
             Logger?.WriteLine($"Located {components.Count()} components to test.", LogType.LOG);
@@ -149,7 +150,7 @@ namespace CorgEng.Tests.NetworkingTests
             //Give it a seed, so tests are repeatable
             Random random = new Random(0);
             //Get all event classes
-            IEnumerable<Type> Events = AppDomain.CurrentDomain.GetAssemblies()
+            IEnumerable<Type> Events = CorgEngMain.LoadedAssemblyModules
                 .SelectMany(assembly => assembly.GetTypes()
                 .Where(type => typeof(INetworkedEvent).IsAssignableFrom(type)));
             Logger?.WriteLine($"Located {Events.Count()} events to test.", LogType.LOG);


### PR DESCRIPTION
Turns out that .NET framework won't support linux. As such, I'll convert the project into a .NET core project.
.NET core however, doesn't support AppDomain, so the uses of this have been replaced.