### PR TITLE
Implements synchronous events

### DIFF
--- a/CorgEng.EntityComponentSystem/Components/Component.cs
+++ b/CorgEng.EntityComponentSystem/Components/Component.cs
@@ -63,9 +63,9 @@ namespace CorgEng.EntityComponentSystem.Components
                 }
                 List<SystemEventHandlerDelegate> systemEventHandlers = RegisteredSystemSignalHandlers[key];
                 //Create a lambda function that injects this component and relays it to the system
-                InternalSignalHandleDelegate componentInjectionLambda = (IEntity entity, IEvent signal) => {
+                InternalSignalHandleDelegate componentInjectionLambda = (IEntity entity, IEvent signal, bool synchronous) => {
                     foreach(SystemEventHandlerDelegate systemEventHandler in systemEventHandlers)
-                        systemEventHandler.Invoke(entity, this, signal);
+                        systemEventHandler.Invoke(entity, this, signal, synchronous);
                 };
                 lock (componentInjectionLambdas)
                 {

--- a/CorgEng.EntityComponentSystem/Components/ComponentExtensions.cs
+++ b/CorgEng.EntityComponentSystem/Components/ComponentExtensions.cs
@@ -47,10 +47,10 @@ namespace CorgEng.EntityComponentSystem.Components
                 }
                 List<SystemEventHandlerDelegate> systemEventHandlers = RegisteredSystemSignalHandlers[key];
                 //Create a lambda function that injects this component and relays it to the system
-                InternalSignalHandleDelegate componentInjectionLambda = (IEntity entity, IEvent signal) =>
+                InternalSignalHandleDelegate componentInjectionLambda = (IEntity entity, IEvent signal, bool synchronous) =>
                 {
                     foreach (SystemEventHandlerDelegate systemEventHandler in systemEventHandlers)
-                        systemEventHandler.Invoke(entity, component, signal);
+                        systemEventHandler.Invoke(entity, component, signal, synchronous);
                 };
                 if (!componentInjectionLambdas.ContainsKey(component))
                 {

--- a/CorgEng.EntityComponentSystem/Entities/Entity.cs
+++ b/CorgEng.EntityComponentSystem/Entities/Entity.cs
@@ -15,7 +15,7 @@ namespace CorgEng.EntityComponentSystem.Entities
     public class Entity : IEntity
     {
 
-        internal delegate void InternalSignalHandleDelegate(IEntity entity, IEvent signal);
+        internal delegate void InternalSignalHandleDelegate(IEntity entity, IEvent signal, bool synchronous);
 
         [UsingDependency]
         private static ILogger Logger;
@@ -90,7 +90,7 @@ namespace CorgEng.EntityComponentSystem.Entities
         /// Internal method for handling signals.
         /// </summary>
         /// <param name="signal"></param>
-        public void HandleSignal(IEvent signal)
+        public void HandleSignal(IEvent signal, bool synchronous = false)
         {
             //Verify that this signal is being listened for
             if (EventListeners == null)
@@ -102,7 +102,7 @@ namespace CorgEng.EntityComponentSystem.Entities
             //Call the signals
             foreach (InternalSignalHandleDelegate internalSignalHandler in signalHandleDelegates)
             {
-                internalSignalHandler.Invoke(this, signal);
+                internalSignalHandler.Invoke(this, signal, synchronous);
             }
         }
 

--- a/CorgEng.EntityComponentSystem/Events/EventExtensions.cs
+++ b/CorgEng.EntityComponentSystem/Events/EventExtensions.cs
@@ -28,30 +28,32 @@ namespace CorgEng.EntityComponentSystem.Events
         /// <summary>
         /// Raise this event against a specified target
         /// </summary>
-        public static void Raise(this IEvent signal, IEntity target)
+        public static void Raise(this IEvent signal, IEntity target, bool synchronous = false)
         {
             Logger.WriteLine($"Event raised {signal}", LogType.DEBUG_EVERYTHING);
             //Handle the signal
-            target.HandleSignal(signal);
+            target.HandleSignal(signal, synchronous);
         }
 
         /// <summary>
         /// Raise this event and network it
         /// </summary>
-        public static void Raise(this INetworkedEvent signal, IEntity target)
+        public static void Raise(this INetworkedEvent signal, IEntity target, bool synchronous = false)
         {
             Logger.WriteLine($"Networked event raised {signal}", LogType.DEBUG_EVERYTHING);
             //Handle the signal
-            target.HandleSignal(signal);
+            target.HandleSignal(signal, synchronous);
             //Inform the entity that networked event was raised
             //Skip directly to signal handling
             target.HandleSignal(new NetworkedEventRaisedEvent(signal));
         }
 
         /// <summary>
-        /// Raise the event globally
+        /// Raise the event globally.
+        /// Use of synchronous is recommended only when there is no other options
+        /// as it will freeze the running thread
         /// </summary>
-        public static void RaiseGlobally(this IEvent signal)
+        public static void RaiseGlobally(this IEvent signal, bool synchronous = false)
         {
             Logger.WriteLine($"Event raised {signal}", LogType.DEBUG_EVERYTHING);
             //Check if we have any registered signals
@@ -64,14 +66,14 @@ namespace CorgEng.EntityComponentSystem.Events
             {
                 List<SystemEventHandlerDelegate> systemEventHandlers = RegisteredSystemSignalHandlers[key];
                 foreach (SystemEventHandlerDelegate systemEventHandler in systemEventHandlers)
-                    systemEventHandler.Invoke(null, null, signal);
+                    systemEventHandler.Invoke(null, null, signal, synchronous);
             }
         }
 
         /// <summary>
         /// Raise the event globally
         /// </summary>
-        public static void RaiseGlobally(this INetworkedEvent signal, bool sourcedLocally = true)
+        public static void RaiseGlobally(this INetworkedEvent signal, bool sourcedLocally = true, bool synchronous = false)
         {
             Logger.WriteLine($"Network event raised {signal}", LogType.DEBUG_EVERYTHING);
             //Check if we have any registered signals
@@ -84,7 +86,7 @@ namespace CorgEng.EntityComponentSystem.Events
             {
                 List<SystemEventHandlerDelegate> systemEventHandlers = RegisteredSystemSignalHandlers[key];
                 foreach (SystemEventHandlerDelegate systemEventHandler in systemEventHandlers)
-                    systemEventHandler.Invoke(null, null, signal);
+                    systemEventHandler.Invoke(null, null, signal, synchronous);
             }
             //Don't relay messages coming from other clients already
             if (!sourcedLocally)
@@ -103,7 +105,7 @@ namespace CorgEng.EntityComponentSystem.Events
             }
             List<SystemEventHandlerDelegate> networkedEventHandlers = RegisteredSystemSignalHandlers[networkKey];
             foreach (SystemEventHandlerDelegate systemEventHandler in networkedEventHandlers)
-                systemEventHandler.Invoke(null, null, new NetworkedEventRaisedEvent(signal));
+                systemEventHandler.Invoke(null, null, new NetworkedEventRaisedEvent(signal), synchronous);
         }
 
     }

--- a/CorgEng.GenericInterfaces/EntityComponentSystem/IEntity.cs
+++ b/CorgEng.GenericInterfaces/EntityComponentSystem/IEntity.cs
@@ -19,7 +19,7 @@ namespace CorgEng.GenericInterfaces.EntityComponentSystem
 
         void RemoveComponent(IComponent component, bool networked);
 
-        void HandleSignal(IEvent signal);
+        void HandleSignal(IEvent signal, bool synchronous = false);
 
         /// <summary>
         /// Gets a component of type. This is slow, avoid using it extensively.

--- a/CorgEng.GenericInterfaces/UserInterface/Attributes/UserInterfaceActionAttribute.cs
+++ b/CorgEng.GenericInterfaces/UserInterface/Attributes/UserInterfaceActionAttribute.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.GenericInterfaces.UserInterface.Attributes
+{
+    /// <summary>
+    /// Attribute to allow for user interfaces to hook onto certain code functions.
+    /// These will be cached on launch for performance.
+    /// 
+    /// <ButtonComponent OnClick="PurchaseItem" />
+    /// 
+    /// [UserInterfaceActionAttribute("PurchaseItem")]
+    /// public static void PurchaseItem(UserInterfaceAction action)
+    /// {
+    ///     ...
+    /// }
+    /// </summary>
+    public class UserInterfaceActionAttribute : Attribute
+    {
+
+        public string Name { get; set; }
+
+    }
+}

--- a/CorgEng.InputHandling/CorgEng.InputHandling.csproj
+++ b/CorgEng.InputHandling/CorgEng.InputHandling.csproj
@@ -42,4 +42,7 @@
   <ItemGroup>
     <PackageReference Include="glfw-net" Version="3.3.1" />
   </ItemGroup>
+  <ItemGroup>
+    <Folder Include="ClickHandler\" />
+  </ItemGroup>
 </Project>

--- a/CorgEng.Tests/EntityComponentSystem/SignalTests.cs
+++ b/CorgEng.Tests/EntityComponentSystem/SignalTests.cs
@@ -242,5 +242,26 @@ namespace CorgEng.Tests.EntityComponentSystem
                 Thread.Sleep(1);
         }
 
+        [TestMethod]
+        [Timeout(1000)]
+        public void TestSynchronousSignalHandling()
+        {
+            Assert.AreEqual(0, handlesReceieved, "INCORRECT TEST CONFIGURATION");
+            Logger?.WriteLine($"Current thread: {Thread.CurrentThread.ManagedThreadId}. TestID: {currentTestId}");
+            //Create a test entity
+            Entity testEntity = new Entity();
+            //Add a test component
+            TestComponent testComponent = new TestComponent();
+            testEntity.AddComponent(testComponent);
+            //Test
+            Assert.AreEqual(0, handlesReceieved);
+            //Send a test signal
+            for (int i = 1; i < 100; i++)
+            {
+                new TestEvent().Raise(testEntity, true);
+                Assert.AreEqual(i, handlesReceieved);
+            }
+        }
+
     }
 }

--- a/CorgEng.Tests/EntityComponentSystem/SignalTests.cs
+++ b/CorgEng.Tests/EntityComponentSystem/SignalTests.cs
@@ -21,6 +21,9 @@ namespace CorgEng.Tests.EntityComponentSystem
 
     internal class TestEvent : IEvent
     {
+
+        public bool Handled { get; set; } = false;
+
         public int TestID { get; }
 
         public TestEvent()
@@ -69,6 +72,7 @@ namespace CorgEng.Tests.EntityComponentSystem
             Console.WriteLine($"[LOCAL EVENT]: Current thread: {Thread.CurrentThread.Name} - {Environment.StackTrace}");
             SignalTests.handlesReceieved++;
             Console.WriteLine(SignalTests.handlesReceieved);
+            eventDetails.Handled = true;
         }
 
         private void HandleSecondaryTestEvent(IEntity entity, SecondaryTestComponent component, TestEvent eventDetails)
@@ -82,12 +86,14 @@ namespace CorgEng.Tests.EntityComponentSystem
             Console.WriteLine($"[LOCAL EVENT]: Current thread: {Thread.CurrentThread.Name} - {Environment.StackTrace}");
             SignalTests.secondaryHandlesReceieved++;
             Console.WriteLine(SignalTests.secondaryHandlesReceieved);
+            eventDetails.Handled = true;
         }
 
         private void HandleGlobalEvent(TestEvent globalEvent)
         {
             Console.WriteLine($"[GLOBAL EVENT]: Current thread: {Thread.CurrentThread.Name}");
             SignalTests.passedGlobalTest = true;
+            globalEvent.Handled = true;
         }
 
     }
@@ -258,8 +264,11 @@ namespace CorgEng.Tests.EntityComponentSystem
             //Send a test signal
             for (int i = 1; i < 100; i++)
             {
-                new TestEvent().Raise(testEntity, true);
+                TestEvent testEvent = new TestEvent();
+                Assert.AreEqual(false, testEvent.Handled);
+                testEvent.Raise(testEntity, true);
                 Assert.AreEqual(i, handlesReceieved);
+                Assert.AreEqual(true, testEvent.Handled);
             }
         }
 

--- a/CorgEng.UserInterface/Components/UserInterfaceBox.cs
+++ b/CorgEng.UserInterface/Components/UserInterfaceBox.cs
@@ -4,6 +4,7 @@ using CorgEng.GenericInterfaces.UserInterface.Anchors;
 using CorgEng.GenericInterfaces.UserInterface.Components;
 using CorgEng.GenericInterfaces.UtilityTypes;
 using CorgEng.UserInterface.Rendering.UserinterfaceRenderer.Box;
+using CorgEng.UserInterface.Style;
 using CorgEng.UtilityTypes.Colours;
 using System;
 using System.Collections.Generic;
@@ -16,11 +17,18 @@ namespace CorgEng.UserInterface.Components
     internal class UserInterfaceBox : UserInterfaceComponent
     {
 
-        private float borderWidth = 5;
+        /// <summary>
+        /// The render object.
+        /// </summary>
+        private UserInterfaceBoxRenderObject boxRenderObject = new UserInterfaceBoxRenderObject();
 
-        private IColour borderColour = new Colour(1, 1, 1);
-
-        private IColour fillColour = new Colour(0, 0, 0);
+        /// <summary>
+        /// Helper property to get the style component of our box
+        /// </summary>
+        public BoxStyle Style
+        {
+            get => boxRenderObject.Style;
+        }
 
         public UserInterfaceBox(IUserInterfaceComponent parent, IAnchor anchorDetails, IDictionary<string, string> arguments) : base(parent, anchorDetails)
         {
@@ -32,22 +40,13 @@ namespace CorgEng.UserInterface.Components
             Setup(arguments);
         }
 
+        /// <summary>
+        /// Setup the component by parsing the styles and starting to render the component
+        /// </summary>
+        /// <param name="arguments"></param>
         private void Setup(IDictionary<string, string> arguments)
         {
-            string output;
-            if (arguments.TryGetValue("borderWidth", out output))
-                borderWidth = float.Parse(output);
-            if (arguments.TryGetValue("borderColour", out output))
-                borderColour = Colour.Parse(output);
-            if (arguments.TryGetValue("fillColour", out output))
-                fillColour = Colour.Parse(output);
-            //Render a box
-            UserInterfaceBoxRenderObject boxRenderObject = new UserInterfaceBoxRenderObject()
-            {
-                BorderWidth = borderWidth,
-                BorderColour = borderColour,
-                FillColour = fillColour,
-            };
+            Style.ParseSettings(arguments);
             userInterfaceBoxRenderer.StartRendering(boxRenderObject);
         }
 

--- a/CorgEng.UserInterface/Components/UserInterfaceButton.cs
+++ b/CorgEng.UserInterface/Components/UserInterfaceButton.cs
@@ -1,0 +1,45 @@
+﻿using CorgEng.GenericInterfaces.UserInterface.Anchors;
+using CorgEng.GenericInterfaces.UserInterface.Components;
+using CorgEng.GenericInterfaces.UtilityTypes;
+using CorgEng.UserInterface.Rendering.UserinterfaceRenderer.Box;
+using CorgEng.UtilityTypes.Colours;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.UserInterface.Components
+{
+    internal class UserInterfaceButton : UserInterfaceComponent
+    {
+
+        public UserInterfaceButton(IUserInterfaceComponent parent, IAnchor anchorDetails, IDictionary<string, string> arguments) : base(parent, anchorDetails)
+        {
+            Setup(arguments);
+        }
+
+        public UserInterfaceButton(IAnchor anchorDetails, IDictionary<string, string> arguments) : base(anchorDetails)
+        {
+            Setup(arguments);
+        }
+
+        private void Setup(IDictionary<string, string> arguments)
+        {
+        }
+
+        private UserInterfaceBoxRenderer userInterfaceBoxRenderer;
+
+        public override void Initialize()
+        {
+            userInterfaceBoxRenderer = new UserInterfaceBoxRenderer();
+            userInterfaceBoxRenderer.Initialize();
+        }
+
+        public override void PerformRender()
+        {
+            userInterfaceBoxRenderer.Render(Width, Height);
+        }
+
+    }
+}

--- a/CorgEng.UserInterface/Rendering/UserinterfaceRenderer/Box/UserInterfaceBoxRenderObject.cs
+++ b/CorgEng.UserInterface/Rendering/UserinterfaceRenderer/Box/UserInterfaceBoxRenderObject.cs
@@ -1,4 +1,5 @@
 ﻿using CorgEng.GenericInterfaces.UtilityTypes;
+using CorgEng.UserInterface.Style;
 using CorgEng.UtilityTypes.Colours;
 using System;
 using System.Collections.Generic;
@@ -11,11 +12,7 @@ namespace CorgEng.UserInterface.Rendering.UserinterfaceRenderer.Box
     internal class UserInterfaceBoxRenderObject : UserInterfaceRenderObject
     {
 
-        public float BorderWidth { get; set; } = 5;
-
-        public IColour BorderColour { get; set; } = new Colour(1, 1, 1);
-
-        public IColour FillColour { get; set; } = new Colour(0, 0, 0);
+        public BoxStyle Style { get; set; } = new BoxStyle();
 
     }
 }

--- a/CorgEng.UserInterface/Rendering/UserinterfaceRenderer/Box/UserInterfaceBoxRenderer.cs
+++ b/CorgEng.UserInterface/Rendering/UserinterfaceRenderer/Box/UserInterfaceBoxRenderer.cs
@@ -25,9 +25,9 @@ namespace CorgEng.UserInterface.Rendering.UserinterfaceRenderer.Box
 
         protected override void BindUniformLocations(UserInterfaceBoxRenderObject userInterfaceBoxRenderObject)
         {
-            glUniform1f(UniformLocationBorderWidth, userInterfaceBoxRenderObject.BorderWidth);
-            glUniform3f(UniformLocationBorderColour, userInterfaceBoxRenderObject.BorderColour.Red, userInterfaceBoxRenderObject.BorderColour.Green, userInterfaceBoxRenderObject.BorderColour.Blue);
-            glUniform3f(UniformLocationFillColour, userInterfaceBoxRenderObject.FillColour.Red, userInterfaceBoxRenderObject.FillColour.Green, userInterfaceBoxRenderObject.FillColour.Blue);
+            glUniform1f(UniformLocationBorderWidth, userInterfaceBoxRenderObject.Style.BorderWidth);
+            glUniform3f(UniformLocationBorderColour, userInterfaceBoxRenderObject.Style.BorderColour.Red, userInterfaceBoxRenderObject.Style.BorderColour.Green, userInterfaceBoxRenderObject.Style.BorderColour.Blue);
+            glUniform3f(UniformLocationFillColour, userInterfaceBoxRenderObject.Style.FillColour.Red, userInterfaceBoxRenderObject.Style.FillColour.Green, userInterfaceBoxRenderObject.Style.FillColour.Blue);
         }
 
 

--- a/CorgEng.UserInterface/Style/BoxStyle.cs
+++ b/CorgEng.UserInterface/Style/BoxStyle.cs
@@ -1,0 +1,32 @@
+﻿using CorgEng.GenericInterfaces.UtilityTypes;
+using CorgEng.UtilityTypes.Colours;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.UserInterface.Style
+{
+    internal class BoxStyle : Style
+    {
+
+        public float BorderWidth { get; set; } = 5;
+
+        public IColour BorderColour { get; set; } = new Colour(1, 1, 1);
+
+        public IColour FillColour { get; set; } = new Colour(0, 0, 0);
+
+        public override void ParseSettings(IDictionary<string, string> settings)
+        {
+            string output;
+            if (settings.TryGetValue("borderWidth", out output))
+                BorderWidth = float.Parse(output);
+            if (settings.TryGetValue("borderColour", out output))
+                BorderColour = Colour.Parse(output);
+            if (settings.TryGetValue("fillColour", out output))
+                FillColour = Colour.Parse(output);
+        }
+
+    }
+}

--- a/CorgEng.UserInterface/Style/Style.cs
+++ b/CorgEng.UserInterface/Style/Style.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.UserInterface.Style
+{
+    internal abstract class Style
+    {
+
+        public abstract void ParseSettings(IDictionary<string, string> settings);
+
+    }
+}


### PR DESCRIPTION
Adds in the ability to make an event fire synchronously.
This means that execution of the current thread will pause until the synchronous event has been handled, and then it will resume.

This can be used when you need to examine the state change of an event after it fires, in case that the signal is not handled by anything or otherwise.
Can be used to get data out of an event after it fires.

To run a synchronous event, simply set synchronous to true when calling event.Raise();

```c#
new TestEvent().Raise(target, true);
new TestEvent().RaiseGlobally(true);
```