### PR TITLE
Input handling & World Fixes

### DIFF
--- a/CorgEng.EntityComponentSystem/Entities/Entity.cs
+++ b/CorgEng.EntityComponentSystem/Entities/Entity.cs
@@ -4,6 +4,7 @@ using CorgEng.EntityComponentSystem.Events;
 using CorgEng.EntityComponentSystem.Events.Events;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Logging;
+using CorgEng.GenericInterfaces.UtilityTypes;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -34,6 +35,11 @@ namespace CorgEng.EntityComponentSystem.Entities
         /// The index of this entity in the contents array of the parent.
         /// </summary>
         public int ContentsIndex { get; set; } = -1;
+
+        /// <summary>
+        /// The location of the contents that we are stored at
+        /// </summary>
+        public IVector<int> ContentsLocation { get; set; }
 
         /// <summary>
         /// Components register themselves to this when needed, and this gets fired off to the component
@@ -118,6 +124,11 @@ namespace CorgEng.EntityComponentSystem.Entities
                 }
             }
             throw new Exception($"Component of type {typeof(T)} was not found on Entity {this}");
+        }
+
+        public override string ToString()
+        {
+            return $"Entity{Identifier}";
         }
 
     }

--- a/CorgEng.EntityComponentSystem/Implementations/Transform/TransformSystem.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Transform/TransformSystem.cs
@@ -1,7 +1,9 @@
-﻿using CorgEng.EntityComponentSystem.Entities;
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.EntityComponentSystem.Entities;
 using CorgEng.EntityComponentSystem.Events;
 using CorgEng.EntityComponentSystem.Systems;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Logging;
 using CorgEng.UtilityTypes.Vectors;
 using System;
 using System.Collections.Generic;
@@ -16,6 +18,9 @@ namespace CorgEng.EntityComponentSystem.Implementations.Transform
 
         //Runs only on the server, triggers MoveEvents from position change events.
         public override EntitySystemFlags SystemFlags { get; } = EntitySystemFlags.HOST_SYSTEM;
+
+        [UsingDependency]
+        private static ILogger Logger;
 
         public override void SystemSetup()
         {

--- a/CorgEng.GenericInterfaces/EntityComponentSystem/IEntity.cs
+++ b/CorgEng.GenericInterfaces/EntityComponentSystem/IEntity.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CorgEng.GenericInterfaces.UtilityTypes;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,6 +13,8 @@ namespace CorgEng.GenericInterfaces.EntityComponentSystem
         List<IComponent> Components { get; }
 
         int ContentsIndex { get; set; }
+
+        IVector<int> ContentsLocation { get; set; }
 
         uint Identifier { get; }
 

--- a/CorgEng.GenericInterfaces/Rendering/Cameras/ICamera.cs
+++ b/CorgEng.GenericInterfaces/Rendering/Cameras/ICamera.cs
@@ -14,5 +14,13 @@ namespace CorgEng.GenericInterfaces.Rendering
 
         IMatrix GetViewMatrix(float windowWidth, float windowHeight);
 
+        /// <summary>
+        /// Converts world coordinates into screen coordinates.
+        /// </summary>
+        /// <param name="x">The X position ranging from -1 to 1</param>
+        /// <param name="y">The Y position ranging from -1 to 1</param>
+        /// <returns></returns>
+        IVector<float> ScreenToWorldCoordinates(double x, double y, float windowWidth, float windowHeight);
+
     }
 }

--- a/CorgEng.InputHandling/ClickHandler/SelectedComponent.cs
+++ b/CorgEng.InputHandling/ClickHandler/SelectedComponent.cs
@@ -1,0 +1,18 @@
+﻿using CorgEng.GenericInterfaces.EntityComponentSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.InputHandling.ClickHandler
+{
+    internal class SelectedComponent : IComponent
+    {
+
+        public bool IsSynced => false;
+
+        public IEntity Parent { get; set; }
+
+    }
+}

--- a/CorgEng.InputHandling/ClickHandler/WorldClickHandler.cs
+++ b/CorgEng.InputHandling/ClickHandler/WorldClickHandler.cs
@@ -1,0 +1,118 @@
+﻿using CorgEng.Core;
+using CorgEng.Core.Dependencies;
+using CorgEng.EntityComponentSystem.Events.Events;
+using CorgEng.EntityComponentSystem.Systems;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Logging;
+using CorgEng.GenericInterfaces.UtilityTypes;
+using CorgEng.GenericInterfaces.World;
+using CorgEng.InputHandling.Events;
+using CorgEng.UtilityTypes.Matrices;
+using CorgEng.UtilityTypes.Vectors;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.InputHandling.ClickHandler
+{
+
+    internal class WorldClickHandler : EntitySystem
+    {
+
+        [UsingDependency]
+        private static ILogger Logger;
+
+        [UsingDependency]
+        private static IWorld World;
+
+        //Track the last clicked location for cyclical selection of entities
+        private static int lastClickedX = 0;
+        private static int lastClickedY = 0;
+        private static IEnumerator<IEntity> contentEnumerator;
+
+        public override EntitySystemFlags SystemFlags => EntitySystemFlags.CLIENT_SYSTEM;
+
+        private SelectedComponent currentSelectedComponent;
+        private IEntity selectedEntity;
+
+        public override void SystemSetup()
+        {
+            RegisterLocalEvent<SelectedComponent, ComponentAddedEvent>(OnComponentAdded);
+            RegisterLocalEvent<SelectedComponent, ComponentRemovedEvent>(OnComponentRemoved);
+        }
+
+        private void OnComponentAdded(IEntity entity, SelectedComponent selectedComponent, ComponentAddedEvent componentAddedEvent)
+        {
+            if (componentAddedEvent.Component != selectedComponent)
+                return;
+            //Unselect the existing entity
+            if (selectedEntity != null)
+            {
+                selectedEntity.RemoveComponent(currentSelectedComponent, false);
+            }
+            //Select this one
+            selectedEntity = entity;
+            currentSelectedComponent = selectedComponent;
+        }
+
+        private void OnComponentRemoved(IEntity entity, SelectedComponent selectedComponent, ComponentRemovedEvent componentRemovedEvent)
+        {
+            //Not the correct component removed
+            if (componentRemovedEvent.Component != selectedComponent)
+                return;
+            //Deselect
+            if (selectedEntity == entity)
+            {
+                selectedEntity = null;
+                currentSelectedComponent = null;
+            }
+        }
+
+        /// <summary>
+        /// Handle the situation where the player clicks, but
+        /// the click isn't intercepted by anything.
+        /// This means that the click should fall through to the world
+        /// to see if anything in the world was clicked.
+        /// 
+        /// This is called directly without going through the signal handler
+        /// as it has to have other signals intercept it first.
+        /// </summary>
+        public static void HandleWorldClick(MouseReleaseEvent releaseEvent, float windowWidth, float windowHeight)
+        {
+            //Transform the clicked position into world position
+            IVector<float> clickedLocation = CorgEngMain.MainCamera.ScreenToWorldCoordinates(releaseEvent.CursorX * 2 - 1, releaseEvent.CursorY * 2 - 1, windowWidth, windowHeight);
+            //Locate the world position that the mouse is currently over
+            int clickedTileX = (int)Math.Round(clickedLocation.X);
+            int clickedTileY = (int)Math.Round(clickedLocation.Y);
+            //Check what we actually pressed on
+            //Determine our click mode
+            //If we clicked on a different tile, reset the last contents index
+            if (lastClickedX != clickedTileX || lastClickedY != clickedTileY || contentEnumerator == null)
+            {
+                contentEnumerator = World.GetContentsAt(clickedTileX, clickedTileY, 0)?.GetContents().GetEnumerator();
+                lastClickedX = clickedTileX;
+                lastClickedY = clickedTileY;
+            }
+            if (contentEnumerator == null)
+            {
+                return;
+            }
+            //If we are on cycle, then only the tile matters.
+            //For now we only support cycle, since its the only one I need
+            //Cycle to the next element
+            if (!contentEnumerator.MoveNext())
+            {
+                contentEnumerator.Reset();
+                if (!contentEnumerator.MoveNext())
+                {
+                    return;
+                }
+            }
+            //Select the element
+            contentEnumerator.Current.AddComponent(new SelectedComponent());
+            Logger.WriteLine($"({releaseEvent.CursorX * 2 - 1}, {releaseEvent.CursorY * 2 - 1}), {clickedLocation} Selected Entity: {contentEnumerator.Current}");
+        }
+    }
+}

--- a/CorgEng.InputHandling/CorgEng.InputHandling.csproj
+++ b/CorgEng.InputHandling/CorgEng.InputHandling.csproj
@@ -42,7 +42,4 @@
   <ItemGroup>
     <PackageReference Include="glfw-net" Version="3.3.1" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="ClickHandler\" />
-  </ItemGroup>
 </Project>

--- a/CorgEng.InputHandling/Events/MouseReleaseEvent.cs
+++ b/CorgEng.InputHandling/Events/MouseReleaseEvent.cs
@@ -30,6 +30,11 @@ namespace CorgEng.InputHandling.Events
         /// </summary>
         public double HeldTime { get; set; }
 
+        /// <summary>
+        /// Was this event handled?
+        /// </summary>
+        public bool Handled { get; set; } = false;
+
         public MouseReleaseEvent(double cursorX, double cursorY, MouseButton mouseButton, ModifierKeys modifierKeys)
         {
             CursorX = cursorX;

--- a/CorgEng.InputHandling/InputHandler.cs
+++ b/CorgEng.InputHandling/InputHandler.cs
@@ -11,6 +11,7 @@ using CorgEng.GenericInterfaces.Logging;
 using CorgEng.Core.Dependencies;
 using CorgEng.EntityComponentSystem.Events;
 using CorgEng.Core;
+using CorgEng.InputHandling.ClickHandler;
 
 namespace CorgEng.InputHandling
 {
@@ -75,7 +76,12 @@ namespace CorgEng.InputHandling
                 case InputState.Release:
                     MouseReleaseEvent mouseReleaseEvent = new MouseReleaseEvent(x / width, y / height, button, modifiers);
                     mouseReleaseEvent.HeldTime = CorgEngMain.Time - mouseDownAt;
-                    mouseReleaseEvent.RaiseGlobally();
+                    //Raise synchronously, so we can determine if the event was handled
+                    mouseReleaseEvent.RaiseGlobally(true);
+                    if (!mouseReleaseEvent.Handled)
+                    {
+                        WorldClickHandler.HandleWorldClick(mouseReleaseEvent, CorgEngMain.GameWindow.Width, CorgEngMain.GameWindow.Height);
+                    }
                     return;
             }
         }

--- a/CorgEng.Rendering/Cameras/Isometic/IsometricCamera.cs
+++ b/CorgEng.Rendering/Cameras/Isometic/IsometricCamera.cs
@@ -2,6 +2,7 @@
 using CorgEng.GenericInterfaces.Rendering.Cameras.Isometric;
 using CorgEng.GenericInterfaces.UtilityTypes;
 using CorgEng.UtilityTypes.Matrices;
+using CorgEng.UtilityTypes.Vectors;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -31,5 +32,14 @@ namespace CorgEng.Rendering.Cameras.Isometic
             return Matrix.GetScaleMatrix(1.0f / (Width * 0.5f), 1.0f / (Height * 0.5f), 1.0f) * Matrix.GetTranslationMatrix(-X, -Y, 0);
         }
 
+        public IVector<float> ScreenToWorldCoordinates(double x, double y, float windowWidth, float windowHeight)
+        {
+            float widthMultiplier = (windowHeight / windowWidth) * (1.0f / (Width * 0.5f));
+            float heightMultiplier = 1.0f / (Height * 0.5f);
+            //Scale the X and Y
+            float worldX = (float)(x / widthMultiplier) - X;
+            float worldY = (float)(y / heightMultiplier) - Y;
+            return new Vector<float>(worldX, -worldY);
+        }
     }
 }

--- a/CorgEng.Tests/World/WorldTests.cs
+++ b/CorgEng.Tests/World/WorldTests.cs
@@ -34,16 +34,16 @@ namespace CorgEng.Tests.World
             //Do some adding and removing
             WorldAccess.AddEntity(entityA, 1, 1, 0);
             WorldAccess.AddEntity(entityB, 1, 1, 0);
-            WorldAccess.AddEntity(entityC, -1.3, 0, 0);
+            WorldAccess.AddEntity(entityC, 0, 0, 0);
             WorldAccess.AddEntity(entityE, -1, 0, 0);
             WorldAccess.AddEntity(entityD, 0, 0, 6);
             WorldAccess.AddEntity("FG", entityF, 0, 0, 6);
             WorldAccess.AddEntity("FG", entityG, 0, 4, 6);
-            WorldAccess.RemoveEntity(entityC, -1.3, 0, 0);
+            WorldAccess.RemoveEntity(entityC, 0, 0, 0);
             WorldAccess.RemoveEntity("FG", entityF, 0, 0, 6);
             WorldAccess.AddEntity("FG", entityF, 0, 0, 7);
-            WorldAccess.AddEntity(entityC, -1.3, 0, 0);
-            WorldAccess.RemoveEntity(entityC, -1.3, 0, 0);
+            WorldAccess.AddEntity(entityC, 1, 1, 0);
+            WorldAccess.RemoveEntity(entityC, 1, 1, 0);
             //Test what we expect
             //(1, 1, 0)
             bool foundA = false;

--- a/CorgEng.World/EntitySystems/WorldSystem.cs
+++ b/CorgEng.World/EntitySystems/WorldSystem.cs
@@ -41,6 +41,8 @@ namespace CorgEng.World.EntitySystems
         /// <param name="componentAddedEvent"></param>
         private void OnEntityCreated(IEntity entity, TransformComponent transformComponent, ComponentAddedEvent componentAddedEvent)
         {
+            if (componentAddedEvent.Component != transformComponent)
+                return;
             //Add the entity to the world
             WorldAccess.AddEntity(entity, transformComponent.Position.X, transformComponent.Position.Y, 0);
         }
@@ -53,7 +55,7 @@ namespace CorgEng.World.EntitySystems
         /// <param name="moveEvent"></param>
         private void OnEntityMoved(IEntity entity, TransformComponent transformComponent, MoveEvent moveEvent)
         {
-            WorldAccess.RemoveEntity(entity, moveEvent.OldPosition.X, moveEvent.OldPosition.Y, 0);
+            WorldAccess.RemoveEntity(entity, entity.ContentsLocation.X, entity.ContentsLocation.Y, 0);
             WorldAccess.AddEntity(entity, moveEvent.NewPosition.X, moveEvent.NewPosition.Y, 0);
         }
 
@@ -65,6 +67,8 @@ namespace CorgEng.World.EntitySystems
         /// <param name="componentRemovedEvent"></param>
         private void OnComponentRemoved(IEntity entity, TransformComponent transformComponent, ComponentRemovedEvent componentRemovedEvent)
         {
+            if (componentRemovedEvent.Component != transformComponent)
+                return;
             WorldAccess.RemoveEntity(entity, transformComponent.Position.X, transformComponent.Position.Y, 0);
         }
 
@@ -77,8 +81,10 @@ namespace CorgEng.World.EntitySystems
         /// <param name="componentAddedEvent"></param>
         private void OnEntityCreated(IEntity entity, TrackComponent trackComponent, ComponentAddedEvent componentAddedEvent)
         {
+            if (componentAddedEvent.Component != trackComponent)
+                return;
             //Add the entity to the world
-            WorldAccess.AddEntity(entity, trackComponent.Transform.Position.X, trackComponent.Transform.Position.Y, 0);
+            WorldAccess.AddEntity(trackComponent.Key, entity, trackComponent.Transform.Position.X, trackComponent.Transform.Position.Y, 0);
         }
 
         /// <summary>
@@ -89,8 +95,8 @@ namespace CorgEng.World.EntitySystems
         /// <param name="moveEvent"></param>
         private void OnEntityMoved(IEntity entity, TrackComponent trackComponent, MoveEvent moveEvent)
         {
-            WorldAccess.RemoveEntity(entity, moveEvent.OldPosition.X, moveEvent.OldPosition.Y, 0);
-            WorldAccess.AddEntity(entity, moveEvent.NewPosition.X, moveEvent.NewPosition.Y, 0);
+            WorldAccess.RemoveEntity(trackComponent.Key, entity, moveEvent.OldPosition.X, moveEvent.OldPosition.Y, 0);
+            WorldAccess.AddEntity(trackComponent.Key, entity, moveEvent.NewPosition.X, moveEvent.NewPosition.Y, 0);
         }
 
         /// <summary>
@@ -101,7 +107,9 @@ namespace CorgEng.World.EntitySystems
         /// <param name="componentRemovedEvent"></param>
         private void OnComponentRemoved(IEntity entity, TrackComponent trackComponent, ComponentRemovedEvent componentRemovedEvent)
         {
-            WorldAccess.RemoveEntity(entity, trackComponent.Transform.Position.X, trackComponent.Transform.Position.Y, 0);
+            if (componentRemovedEvent.Component != trackComponent)
+                return;
+            WorldAccess.RemoveEntity(trackComponent.Key, entity, trackComponent.Transform.Position.X, trackComponent.Transform.Position.Y, 0);
         }
 
     }

--- a/CorgEng.World/WorldTracking/ContentsEnumerator.cs
+++ b/CorgEng.World/WorldTracking/ContentsEnumerator.cs
@@ -21,7 +21,7 @@ namespace CorgEng.World.WorldTracking
             reference = contentsHolder;
         }
 
-        public IEntity Current => reference.contentsArray[head];
+        public IEntity Current => head < reference.contentsArray.Length ? reference.contentsArray[head] : null;
 
         object IEnumerator.Current => reference.contentsArray[head];
 
@@ -37,7 +37,7 @@ namespace CorgEng.World.WorldTracking
             do
             {
                 head++;
-                if (head == reference.nextInsertionPointer)
+                if (head == reference.nextInsertionPointer || head >= reference.contentsArray.Length)
                     return false;
             }
             while (Current == null);
@@ -46,7 +46,7 @@ namespace CorgEng.World.WorldTracking
 
         public void Reset()
         {
-            head = 0;
+            head = -1;
         }
 
     }

--- a/CorgEng.World/WorldTracking/ContentsHolder.cs
+++ b/CorgEng.World/WorldTracking/ContentsHolder.cs
@@ -1,6 +1,9 @@
-﻿using CorgEng.EntityComponentSystem.Entities;
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.EntityComponentSystem.Entities;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Logging;
 using CorgEng.GenericInterfaces.World;
+using CorgEng.UtilityTypes.Vectors;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,7 +41,14 @@ namespace CorgEng.World.WorldTracking
         /// Maximum value used in the array
         /// </summary>
         internal int nextInsertionPointer = 0;
-        
+
+        private Vector<int> position;
+
+        public ContentsHolder(int x, int y)
+        {
+            position = new Vector<int>(x, y);
+        }
+
         public IEnumerable<IEntity> GetContents()
         {
             return new ContentsEnumerable(this);
@@ -72,6 +82,7 @@ namespace CorgEng.World.WorldTracking
             }
             //Insert the entity
             entity.ContentsIndex = nextInsertionPointer;
+            entity.ContentsLocation = position;
             contentsArray[nextInsertionPointer] = entity;
             //Insert the next entity in the next position
             nextInsertionPointer++;
@@ -80,7 +91,7 @@ namespace CorgEng.World.WorldTracking
         public void Remove(IEntity entity)
         {
             //Validation check
-            if (contentsArray[entity.ContentsIndex] != entity)
+            if (entity.ContentsIndex >= contentsArray.Length || entity.ContentsIndex < 0 || contentsArray[entity.ContentsIndex] != entity)
                 throw new Exception($"Invalid entity in WorldTile array, entity claims to be at position {entity.ContentsIndex}");
             //Remove the entity
             contentsArray[entity.ContentsIndex] = null;

--- a/CorgEng.World/WorldTracking/World.cs
+++ b/CorgEng.World/WorldTracking/World.cs
@@ -2,6 +2,7 @@
 using CorgEng.DependencyInjection.Dependencies;
 using CorgEng.EntityComponentSystem.Entities;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Logging;
 using CorgEng.GenericInterfaces.UtilityTypes.BinaryLists;
 using CorgEng.GenericInterfaces.World;
 using System;
@@ -56,7 +57,7 @@ namespace CorgEng.World.WorldTracking
             ContentsHolder worldTile = targetLevel.Get(xInteger, yInteger);
             if (worldTile == null)
             {
-                worldTile = new ContentsHolder();
+                worldTile = new ContentsHolder(xInteger, yInteger);
                 targetLevel.Add(xInteger, yInteger, worldTile);
             }
             worldTile.Insert(entity);


### PR DESCRIPTION
Due to movement requests having to go through the transform system first, the actual move calls are delayed. This could result in the transform added event being called before the move response event in the world resulting in the old position of the event being different to the spawned position.
To fix this, rather than using old position we track the position of every entity in the world.

Also adds in entity selection, so you can click on entities to select them.