### PR TITLE
Overlay rendering

### DIFF
--- a/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/AddOverlayEvent.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/AddOverlayEvent.cs
@@ -1,5 +1,4 @@
 ﻿using CorgEng.Core.Dependencies;
-using CorgEng.EntityComponentSystem.Events;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Rendering.Icons;
 using CorgEng.GenericInterfaces.Serialization;
@@ -12,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRendering
 {
-    public class SetSpriteEvent : INetworkedEvent
+    public class AddOverlayEvent : INetworkedEvent
     {
 
         [UsingDependency]
@@ -22,7 +21,7 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
 
         public IIcon TextureFile { get; set; }
 
-        public SetSpriteEvent(IIcon textureFile)
+        public AddOverlayEvent(IIcon textureFile)
         {
             TextureFile = textureFile;
         }
@@ -41,5 +40,6 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
         {
             return AutoSerialiser.SerialisationLength(typeof(IIcon), TextureFile);
         }
+
     }
 }

--- a/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/RemoveOverlayEvent.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/RemoveOverlayEvent.cs
@@ -1,5 +1,4 @@
 ﻿using CorgEng.Core.Dependencies;
-using CorgEng.EntityComponentSystem.Events;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Rendering.Icons;
 using CorgEng.GenericInterfaces.Serialization;
@@ -12,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRendering
 {
-    public class SetSpriteEvent : INetworkedEvent
+    public class RemoveOverlayEvent : INetworkedEvent
     {
 
         [UsingDependency]
@@ -22,7 +21,7 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
 
         public IIcon TextureFile { get; set; }
 
-        public SetSpriteEvent(IIcon textureFile)
+        public RemoveOverlayEvent(IIcon textureFile)
         {
             TextureFile = textureFile;
         }
@@ -41,5 +40,6 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
         {
             return AutoSerialiser.SerialisationLength(typeof(IIcon), TextureFile);
         }
+
     }
 }

--- a/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderComponent.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderComponent.cs
@@ -1,6 +1,7 @@
 ﻿using CorgEng.EntityComponentSystem.Components;
 using CorgEng.GenericInterfaces.ContentLoading;
 using CorgEng.GenericInterfaces.Networking.Attributes;
+using CorgEng.GenericInterfaces.Rendering.Icons;
 using CorgEng.GenericInterfaces.Rendering.Renderers.SpriteRendering;
 using CorgEng.GenericInterfaces.Rendering.RenderObjects.SpriteRendering;
 using CorgEng.GenericInterfaces.UtilityTypes;
@@ -20,7 +21,7 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
         public IVector<float> CachedPosition { get; set; } = null;
 
         [NetworkSerialized]
-        public string Sprite { get; set; }
+        public IIcon Sprite { get; set; }
 
         public ISpriteRenderObject SpriteRenderObject { get; internal set; }
 
@@ -28,6 +29,7 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
         public uint SpriteRendererIdentifier { get; set; }
 
         private uint cachedSpriteRendererIdentifier = 0;
+
         private ISpriteRenderer _spriteRenderer;
 
         public ISpriteRenderer SpriteRenderer
@@ -47,12 +49,6 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
 
         public override bool SetProperty(string name, IPropertyDef property)
         {
-            switch (name)
-            {
-                case "Sprite":
-                    Sprite = (string)property.GetValue(Vector<float>.Zero);
-                    return true;
-            }
             return false;
         }
     }

--- a/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderSystem.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderSystem.cs
@@ -40,6 +40,8 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
             RegisterLocalEvent<SpriteRenderComponent, DeleteEntityEvent>(OnEntityDestroyed);
             RegisterLocalEvent<SpriteRenderComponent, MoveEvent>(OnEntityMoved);
             RegisterLocalEvent<SpriteRenderComponent, InitialiseNetworkedEntityEvent>(OnInitialise);
+            RegisterLocalEvent<SpriteRenderComponent, AddOverlayEvent>(AddOverlay);
+            RegisterLocalEvent<SpriteRenderComponent, RemoveOverlayEvent>(RemoveOverlay);
         }
 
         private void OnInitialise(IEntity entity, SpriteRenderComponent spriteRenderComponent, InitialiseNetworkedEntityEvent componentAddedEvent)
@@ -74,8 +76,8 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
             }
             else
             {
-                spriteRenderComponent.SpriteRenderObject.Transform.Value[3, 1] = moveEvent.NewPosition.X;
-                spriteRenderComponent.SpriteRenderObject.Transform.Value[3, 2] = moveEvent.NewPosition.Y;
+                spriteRenderComponent.SpriteRenderObject.CombinedTransform.Value[3, 1] = moveEvent.NewPosition.X;
+                spriteRenderComponent.SpriteRenderObject.CombinedTransform.Value[3, 2] = moveEvent.NewPosition.Y;
             }
         }
 
@@ -124,14 +126,36 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
                     newTexture.OffsetHeight);
                 if (spriteRenderComponent.CachedPosition != null)
                 {
-                    spriteRenderComponent.SpriteRenderObject.Transform.Value[3, 1] = spriteRenderComponent.CachedPosition.X;
-                    spriteRenderComponent.SpriteRenderObject.Transform.Value[3, 2] = spriteRenderComponent.CachedPosition.Y;
+                    spriteRenderComponent.SpriteRenderObject.CombinedTransform.Value[3, 1] = spriteRenderComponent.CachedPosition.X;
+                    spriteRenderComponent.SpriteRenderObject.CombinedTransform.Value[3, 2] = spriteRenderComponent.CachedPosition.Y;
                     spriteRenderComponent.CachedPosition = null;
                 }
                 //Start rendering
                 if (spriteRenderComponent.SpriteRenderer != null)
                     spriteRenderComponent.SpriteRenderer.StartRendering(spriteRenderComponent.SpriteRenderObject);
             }
+        }
+
+        /// <summary>
+        /// Adds an overlay to this sprite
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="spriteRenderComponent"></param>
+        /// <param name="addOverlayEvent"></param>
+        private void AddOverlay(IEntity entity, SpriteRenderComponent spriteRenderComponent, AddOverlayEvent addOverlayEvent)
+        {
+            spriteRenderComponent.SpriteRenderObject.AddOverlay(addOverlayEvent.TextureFile);
+        }
+
+        /// <summary>
+        /// Remove an overlay from this sprite
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="spriteRenderComponent"></param>
+        /// <param name="removeOverlayEvent"></param>
+        private void RemoveOverlay(IEntity entity, SpriteRenderComponent spriteRenderComponent, RemoveOverlayEvent removeOverlayEvent)
+        {
+            spriteRenderComponent.SpriteRenderObject.RemoveOverlay(removeOverlayEvent.TextureFile);
         }
 
     }

--- a/CorgEng.Example.Server/Program.cs
+++ b/CorgEng.Example.Server/Program.cs
@@ -15,6 +15,7 @@ using CorgEng.GenericInterfaces.Logging;
 using CorgEng.GenericInterfaces.Networking.Networking.Server;
 using CorgEng.GenericInterfaces.Networking.PrototypeManager;
 using CorgEng.GenericInterfaces.Rendering.Cameras.Isometric;
+using CorgEng.GenericInterfaces.Rendering.Icons;
 using CorgEng.InputHandling.Events;
 using CorgEng.Networking.Components;
 using CorgEng.UtilityTypes.Vectors;
@@ -45,6 +46,9 @@ namespace CorgEng.Example.Server
         private static IIsometricCameraFactory IsometricCameraFactory;
 #endif
 
+        [UsingDependency]
+        private static IIconFactory IconFactory;
+
         static void Main(string[] args)
         {
             //Load the application config
@@ -73,7 +77,7 @@ namespace CorgEng.Example.Server
                     testingEntity.AddComponent(new SpriteRenderComponent());
                     //Update the entity
                     new SetPositionEvent(new Vector<float>(x, y)).Raise(testingEntity);
-                    new SetSpriteEvent("human.ghost").Raise(testingEntity);
+                    new SetSpriteEvent(IconFactory.CreateIcon("human.ghost")).Raise(testingEntity);
                     new SetSpriteRendererEvent(1).Raise(testingEntity);
                 }
             }
@@ -102,7 +106,7 @@ namespace CorgEng.Example.Server
             IEntity playerPrototype = new Entity();
             playerPrototype.AddComponent(new ClientComponent());
             playerPrototype.AddComponent(new NetworkTransformComponent());
-            playerPrototype.AddComponent(new SpriteRenderComponent() { Sprite = "human.ghost", SpriteRendererIdentifier = 1 });
+            playerPrototype.AddComponent(new SpriteRenderComponent() { Sprite = IconFactory.CreateIcon("human.ghost"), SpriteRendererIdentifier = 1 });
             playerPrototype.AddComponent(new PlayerMovementComponent());
             playerPrototype.AddComponent(new DeleteableComponent());
             IPrototype prototype = PrototypeManager.GetPrototype(playerPrototype);

--- a/CorgEng.GenericInterfaces/Rendering/Icons/IIcon.cs
+++ b/CorgEng.GenericInterfaces/Rendering/Icons/IIcon.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.GenericInterfaces.Rendering.Icons
+{
+    internal interface IIcon
+    {
+    }
+}

--- a/CorgEng.GenericInterfaces/Rendering/Icons/IIconFactory.cs
+++ b/CorgEng.GenericInterfaces/Rendering/Icons/IIconFactory.cs
@@ -1,5 +1,4 @@
-﻿using CorgEng.GenericInterfaces.Networking.Serialisation;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -7,10 +6,10 @@ using System.Threading.Tasks;
 
 namespace CorgEng.GenericInterfaces.Rendering.Icons
 {
-    public interface IIcon : ICustomSerialisationBehaviour
+    public interface IIconFactory
     {
 
-        string IconName { get; }
+        IIcon CreateIcon(string name);
 
     }
 }

--- a/CorgEng.GenericInterfaces/Rendering/RenderObjects/IRenderObject.cs
+++ b/CorgEng.GenericInterfaces/Rendering/RenderObjects/IRenderObject.cs
@@ -18,19 +18,19 @@ namespace CorgEng.GenericInterfaces.Rendering.RenderObjects
         /// The transform applied to this render object.
         /// Used externally, will trigger updates to the transform rows automatically.
         /// </summary>
-        IBindableProperty<IMatrix> Transform { get; }
+        IBindableProperty<IMatrix> CombinedTransform { get; }
 
         /// <summary>
         /// The first row of the transfomation matrix.
         /// Updated internally by the renderers and shouldn't be interfaced with directly.
         /// </summary>
-        IBindableProperty<IVector<float>> TransformFirstRow { get; }
+        IBindableProperty<IVector<float>> CombinedTransformFirstRow { get; }
 
         /// <summary>
         /// The second row of the transfomation matrix.
         /// Updated internally by the renderers and shouldn't be interfaced with directly.
         /// </summary>
-        IBindableProperty<IVector<float>> TransformSecondRow { get; }
+        IBindableProperty<IVector<float>> CombinedTransformSecondRow { get; }
 
         void SetBelongingBatchElement<BatchType>(IBatchElement<BatchType> heldBatch)
             where BatchType : IBatch<BatchType>;

--- a/CorgEng.GenericInterfaces/Rendering/RenderObjects/SpriteRendering/ISpriteRenderObject.cs
+++ b/CorgEng.GenericInterfaces/Rendering/RenderObjects/SpriteRendering/ISpriteRenderObject.cs
@@ -1,4 +1,6 @@
-﻿using CorgEng.GenericInterfaces.UtilityTypes;
+﻿using CorgEng.GenericInterfaces.Rendering.Icons;
+using CorgEng.GenericInterfaces.Rendering.Renderers.SpriteRendering;
+using CorgEng.GenericInterfaces.UtilityTypes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,7 +18,33 @@ namespace CorgEng.GenericInterfaces.Rendering.RenderObjects.SpriteRendering
         IBindableProperty<float> TextureFileY { get; set; }
 
         IBindableProperty<float> TextureFileHeight { get; set; }
+
+        /// <summary>
+        /// A bindable property representing the width of this icon within the parent texture file.
+        /// Will automatically update the renderer if changed.
+        /// </summary>
         IBindableProperty<float> TextureFileWidth { get; set; }
+
+        /// <summary>
+        /// If we are an overlay, this is the object we are being rendered inside of.
+        /// </summary>
+        ISpriteRenderObject Container { get; set; }
+
+        /// <summary>
+        /// The renderer that is currently rendering us.
+        /// 
+        /// This is managed internally by the renderer and shouldn't be
+        /// assigned to outside of the renderer.
+        /// </summary>
+        ISpriteRenderer CurrentRenderer { get; set; }
+
+        /// <summary>
+        /// The transform of this, ignoring the parent transform.
+        /// Required for overlays.
+        /// 
+        /// Updating the value of the transform will automatically
+        /// </summary>
+        IBindableProperty<IMatrix> SelfTransform { get; set; }
 
         /// <summary>
         /// The texture detail wrapper
@@ -27,13 +55,13 @@ namespace CorgEng.GenericInterfaces.Rendering.RenderObjects.SpriteRendering
         /// Add an overlay to be rendered on top of this object
         /// </summary>
         /// <param name="overlay">The overlay to be rendered along with this object</param>
-        void AddOverlay(ISpriteRenderObject overlay);
+        void AddOverlay(IIcon overlay);
 
         /// <summary>
         /// Removes an overlay that is currently applied to this render object.
         /// </summary>
         /// <param name="overlay">The overlay to be removed</param>
-        void RemoveOverlay(ISpriteRenderObject overlay);
+        void RemoveOverlay(IIcon overlay);
 
     }
 }

--- a/CorgEng.GenericInterfaces/Rendering/RenderObjects/SpriteRendering/ISpriteRenderObject.cs
+++ b/CorgEng.GenericInterfaces/Rendering/RenderObjects/SpriteRendering/ISpriteRenderObject.cs
@@ -18,7 +18,22 @@ namespace CorgEng.GenericInterfaces.Rendering.RenderObjects.SpriteRendering
         IBindableProperty<float> TextureFileHeight { get; set; }
         IBindableProperty<float> TextureFileWidth { get; set; }
 
+        /// <summary>
+        /// The texture detail wrapper
+        /// </summary>
         IBindablePropertyGroup TextureDetails { get; }
+
+        /// <summary>
+        /// Add an overlay to be rendered on top of this object
+        /// </summary>
+        /// <param name="overlay">The overlay to be rendered along with this object</param>
+        void AddOverlay(ISpriteRenderObject overlay);
+
+        /// <summary>
+        /// Removes an overlay that is currently applied to this render object.
+        /// </summary>
+        /// <param name="overlay">The overlay to be removed</param>
+        void RemoveOverlay(ISpriteRenderObject overlay);
 
     }
 }

--- a/CorgEng.GenericInterfaces/Rendering/Textures/ITextureFactory.cs
+++ b/CorgEng.GenericInterfaces/Rendering/Textures/ITextureFactory.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CorgEng.GenericInterfaces.Rendering.Icons;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -11,7 +12,7 @@ namespace CorgEng.GenericInterfaces.Rendering.Textures
 
         ITexture CreateTexture(string texturePath);
 
-        ITextureState GetTextureFromIconState(string iconState);
+        ITextureState GetTextureFromIconState(IIcon iconState);
 
     }
 }

--- a/CorgEng.GenericInterfaces/UtilityTypes/IMatrix.cs
+++ b/CorgEng.GenericInterfaces/UtilityTypes/IMatrix.cs
@@ -18,5 +18,12 @@ namespace CorgEng.GenericInterfaces.UtilityTypes
 
         unsafe float* GetPointer();
 
+        /// <summary>
+        /// Multiply this matrix with another matrix and return the result as a new matrix
+        /// </summary>
+        /// <param name="other"></param>
+        /// <returns></returns>
+        IMatrix Multiply(IMatrix other);
+
     }
 }

--- a/CorgEng.Rendering/Icons/Icon.cs
+++ b/CorgEng.Rendering/Icons/Icon.cs
@@ -1,0 +1,42 @@
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.GenericInterfaces.Rendering.Icons;
+using CorgEng.GenericInterfaces.Serialization;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.Rendering.Icons
+{
+    internal class Icon : IIcon
+    {
+
+        [UsingDependency]
+        private static IAutoSerialiser AutoSerialiser;
+
+        public string IconName { get; private set; }
+
+        public Icon(string iconName)
+        {
+            IconName = iconName;
+        }
+
+        public void DeserialiseFrom(BinaryReader binaryReader)
+        {
+            IconName = AutoSerialiser.Deserialize(typeof(string), binaryReader) as string;
+        }
+
+        public int GetSerialisationLength()
+        {
+            return AutoSerialiser.SerialisationLength(typeof(string), IconName);
+        }
+
+        public void SerialiseInto(BinaryWriter binaryWriter)
+        {
+            AutoSerialiser.SerializeInto(typeof(string), IconName, binaryWriter);
+        }
+
+    }
+}

--- a/CorgEng.Rendering/Icons/IconFactory.cs
+++ b/CorgEng.Rendering/Icons/IconFactory.cs
@@ -1,0 +1,21 @@
+﻿using CorgEng.DependencyInjection.Dependencies;
+using CorgEng.GenericInterfaces.Rendering.Icons;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.Rendering.Icons
+{
+    [Dependency]
+    internal class IconFactory : IIconFactory
+    {
+
+        public IIcon CreateIcon(string name)
+        {
+            return new Icon(name);
+        }
+
+    }
+}

--- a/CorgEng.Rendering/SpriteRendering/SpriteRenderObject.cs
+++ b/CorgEng.Rendering/SpriteRendering/SpriteRenderObject.cs
@@ -43,6 +43,11 @@ namespace CorgEng.Rendering.SpriteRendering
 
         public IBindableProperty<IVector<float>> TransformSecondRow { get; } = new BindableProperty<IVector<float>>(new Vector<float>(0, 1, 0));
 
+        /// <summary>
+        /// A hashset containing all overlays that are currently attached to us
+        /// </summary>
+        private HashSet<ISpriteRenderObject> overlays = new HashSet<ISpriteRenderObject>();
+
         public SpriteRenderObject(uint textureUint, float textureX, float textureY, float textureWidth, float textureHeight)
         {
             //When the vector changes, trigger change on the bindable property.
@@ -58,6 +63,11 @@ namespace CorgEng.Rendering.SpriteRendering
                 TransformSecondRow.TriggerChanged();
                 //Trigger a transform update
                 Transform.TriggerChanged();
+                //Update overlays
+                foreach (ISpriteRenderObject overlayObject in overlays)
+                {
+                    overlayObject.Transform.Value = Transform.Value;
+                }
             };
             //Set the bindable properties
             TextureFile = new BindableProperty<uint>(textureUint);
@@ -95,6 +105,19 @@ namespace CorgEng.Rendering.SpriteRendering
         {
             //TODO: Textures can be loaded from the def file
             return false;
+        }
+
+        public void AddOverlay(ISpriteRenderObject overlay)
+        {
+            //Add the overlay
+            overlays.Add(overlay);
+        }
+
+        public void RemoveOverlay(ISpriteRenderObject overlay)
+        {
+            //Remove the overlay
+            overlays.Remove(overlay);
+            
         }
 
     }

--- a/CorgEng.Rendering/SpriteRendering/SpriteRenderer.cs
+++ b/CorgEng.Rendering/SpriteRendering/SpriteRenderer.cs
@@ -41,10 +41,12 @@ namespace CorgEng.Rendering.SpriteRendering
             //Check for duplicate render exceptions
             if (spriteRenderObject.GetBelongingBatchElement<SpriteBatch>() != null)
                 throw new DuplicateRenderException("Attempting to render a sprite object already being rendered.");
+            //Indicate that we are rendering
+            spriteRenderObject.CurrentRenderer = this;
             //Create a new batch element for this
             IBatchElement<SpriteBatch> batchElement = new BatchElement<SpriteBatch>(new IBindableProperty<IVector<float>>[] {
-                spriteRenderObject.TransformFirstRow,
-                spriteRenderObject.TransformSecondRow,
+                spriteRenderObject.CombinedTransformFirstRow,
+                spriteRenderObject.CombinedTransformSecondRow,
                 spriteRenderObject.TextureDetails
             });
             //Remember the batch element we are stored in, so it can be saved
@@ -55,6 +57,10 @@ namespace CorgEng.Rendering.SpriteRendering
 
         public void StopRendering(ISpriteRenderObject spriteRenderObject)
         {
+            if (spriteRenderObject.CurrentRenderer != this)
+                throw new Exception("Attempted to stop rendering a render object thats not rendering on this renderer.");
+            //Stop rendering
+            spriteRenderObject.CurrentRenderer = null;
             //Remove references to the on change event
             spriteRenderObject.GetBelongingBatchElement<SpriteBatch>().Unbind();
             //Remove the batch element

--- a/CorgEng.Rendering/TextRendering/TextObject.cs
+++ b/CorgEng.Rendering/TextRendering/TextObject.cs
@@ -83,10 +83,10 @@ namespace CorgEng.Rendering.TextRendering
                     (float)fontCharacter.TextureYPosition / fontCharacter.TextureFile.Height,
                     (float)fontCharacter.TextureWidth / fontCharacter.TextureFile.Width,
                     (float)fontCharacter.TextureHeight / fontCharacter.TextureFile.Height);
-                renderObject.Transform.Value[3, 1] = (float)xPointer + Scale.Value * 4 * fontCharacter.CharacterXOffset / fontCharacter.TextureFile.Width;
-                renderObject.Transform.Value[3, 2] = (float)yPointer - Scale.Value * 4 * fontCharacter.CharacterYOffset / fontCharacter.TextureFile.Height;
-                renderObject.Transform.Value[1, 1] = Scale.Value * 8 * fontCharacter.TextureWidth / fontCharacter.TextureFile.Width;
-                renderObject.Transform.Value[2, 2] = Scale.Value * 8 * fontCharacter.TextureHeight / fontCharacter.TextureFile.Height;
+                renderObject.CombinedTransform.Value[3, 1] = (float)xPointer + Scale.Value * 4 * fontCharacter.CharacterXOffset / fontCharacter.TextureFile.Width;
+                renderObject.CombinedTransform.Value[3, 2] = (float)yPointer - Scale.Value * 4 * fontCharacter.CharacterYOffset / fontCharacter.TextureFile.Height;
+                renderObject.CombinedTransform.Value[1, 1] = Scale.Value * 8 * fontCharacter.TextureWidth / fontCharacter.TextureFile.Width;
+                renderObject.CombinedTransform.Value[2, 2] = Scale.Value * 8 * fontCharacter.TextureHeight / fontCharacter.TextureFile.Height;
                 //Start rendering the character
                 spriteRenderer.StartRendering(renderObject);
                 //Move forward the pointers (Account for the font width)

--- a/CorgEng.Rendering/Textures/TextureFactory.cs
+++ b/CorgEng.Rendering/Textures/TextureFactory.cs
@@ -1,4 +1,5 @@
 ﻿using CorgEng.DependencyInjection.Dependencies;
+using CorgEng.GenericInterfaces.Rendering.Icons;
 using CorgEng.GenericInterfaces.Rendering.Textures;
 using System;
 using System.Collections.Generic;
@@ -29,9 +30,9 @@ namespace CorgEng.Rendering.Textures
             throw new NotImplementedException($"Texture file extension .{fileExtension} is not supported.");
         }
 
-        public ITextureState GetTextureFromIconState(string iconState)
+        public ITextureState GetTextureFromIconState(IIcon iconState)
         {
-            return TextureCache.GetTexture(iconState);
+            return TextureCache.GetTexture(iconState.IconName);
         }
     }
 }

--- a/CorgEng.Tests/Stubs/TextureFactoryStub.cs
+++ b/CorgEng.Tests/Stubs/TextureFactoryStub.cs
@@ -1,4 +1,5 @@
-﻿using CorgEng.GenericInterfaces.Rendering.Textures;
+﻿using CorgEng.GenericInterfaces.Rendering.Icons;
+using CorgEng.GenericInterfaces.Rendering.Textures;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -24,7 +25,7 @@ namespace CorgEng.Tests.Stubs
             throw new NotImplementedException($"Texture file extension .{fileExtension} is not supported.");
         }
 
-        public ITextureState GetTextureFromIconState(string iconState)
+        public ITextureState GetTextureFromIconState(IIcon iconState)
         {
             return null;
         }

--- a/CorgEng.UserInterface/Rendering/UserinterfaceRenderer/UserInterfaceRenderObject.cs
+++ b/CorgEng.UserInterface/Rendering/UserinterfaceRenderer/UserInterfaceRenderObject.cs
@@ -17,16 +17,16 @@ namespace CorgEng.UserInterface.Rendering.UserinterfaceRenderer
     public class UserInterfaceRenderObject : IUserInterfaceRenderObject
     {
 
-        public IBindableProperty<IMatrix> Transform { get; } = new BindableProperty<IMatrix>(new Matrix(new float[,] {
+        public IBindableProperty<IMatrix> CombinedTransform { get; } = new BindableProperty<IMatrix>(new Matrix(new float[,] {
             { 1, 0, 0 },
             { 0, 1, 0 },
             //This last row is actually ignored (It's not needed in 2 dimensional applications)
             { 0, 0, 1 }
         }));
 
-        public IBindableProperty<IVector<float>> TransformFirstRow { get; } = new BindableProperty<IVector<float>>(new Vector<float>(1, 0, 0));
+        public IBindableProperty<IVector<float>> CombinedTransformFirstRow { get; } = new BindableProperty<IVector<float>>(new Vector<float>(1, 0, 0));
 
-        public IBindableProperty<IVector<float>> TransformSecondRow { get; } = new BindableProperty<IVector<float>>(new Vector<float>(0, 1, 0));
+        public IBindableProperty<IVector<float>> CombinedTransformSecondRow { get; } = new BindableProperty<IVector<float>>(new Vector<float>(0, 1, 0));
 
         public IBindablePropertyGroup TextureDetails { get; }
 
@@ -35,16 +35,16 @@ namespace CorgEng.UserInterface.Rendering.UserinterfaceRenderer
         public UserInterfaceRenderObject()
         {
             //When the vector changes, trigger change on the bindable property.
-            Transform.Value.OnChange += (object src, EventArgs arg) => {
+            CombinedTransform.Value.OnChange += (object src, EventArgs arg) => {
                 //Trigger updates to our transform rows
-                TransformFirstRow.Value.X = Transform.Value[1, 1];
-                TransformFirstRow.Value.Y = Transform.Value[2, 1];
-                TransformFirstRow.Value.Z = Transform.Value[3, 1];
-                TransformFirstRow.TriggerChanged();
-                TransformSecondRow.Value.X = Transform.Value[1, 2];
-                TransformSecondRow.Value.Y = Transform.Value[2, 2];
-                TransformSecondRow.Value.Z = Transform.Value[3, 2];
-                TransformSecondRow.TriggerChanged();
+                CombinedTransformFirstRow.Value.X = CombinedTransform.Value[1, 1];
+                CombinedTransformFirstRow.Value.Y = CombinedTransform.Value[2, 1];
+                CombinedTransformFirstRow.Value.Z = CombinedTransform.Value[3, 1];
+                CombinedTransformFirstRow.TriggerChanged();
+                CombinedTransformSecondRow.Value.X = CombinedTransform.Value[1, 2];
+                CombinedTransformSecondRow.Value.Y = CombinedTransform.Value[2, 2];
+                CombinedTransformSecondRow.Value.Z = CombinedTransform.Value[3, 2];
+                CombinedTransformSecondRow.TriggerChanged();
             };
         }
 

--- a/CorgEng.UtilityTypes/Matrices/Matrix.cs
+++ b/CorgEng.UtilityTypes/Matrices/Matrix.cs
@@ -215,6 +215,34 @@ namespace CorgEng.UtilityTypes.Matrices
             return outputMatrix;
         }
 
+        public IMatrix Multiply(IMatrix other)
+        {
+            //Check to make sure the matrices can be multiplied together
+            if (X != other.Y) throw new InvalidMatrixDimensionError($"Invalid matrix dimensions: a.X ({X}) != b.Y ({other.Y})");
+            int dotProductLength = other.X;
+            //Create the new output matrix
+            Matrix outputMatrix = new Matrix(other.X, other.Y);
+
+            //For each column in the output matrix
+            for (int x = 1; x <= other.X; x++)
+            {
+                //And each row in the output matrix
+                for (int y = 1; y <= other.Y; y++)
+                {
+                    float dotProductSum = 0;
+                    //The result is the dot product of the rows
+                    for (int i = 1; i <= dotProductLength; i++)
+                    {
+                        dotProductSum += this[i, y] * other[x, i];
+                    }
+                    //Calculate the result
+                    outputMatrix[x, y] = dotProductSum;
+                }
+            }
+            //Return the result
+            return outputMatrix;
+        }
+
         /// <summary>
         /// Returns the appropriate translation matrix
         /// </summary>


### PR DESCRIPTION
closes #47

Adds in the ability to add overlays to spriterendercomponents.

Overlays will have their own transform multiplied by the parent's transform if it is changed.

![image](https://user-images.githubusercontent.com/26465327/183686107-766fc73f-4c30-4131-ac7f-2e5e04a4e25a.png)
