### PR TITLE
Some minor changes and fixes to the world click handler

### DIFF
--- a/CorgEng.InputHandling/ClickHandler/EntityDeselectedEvent.cs
+++ b/CorgEng.InputHandling/ClickHandler/EntityDeselectedEvent.cs
@@ -1,0 +1,27 @@
+﻿using CorgEng.GenericInterfaces.EntityComponentSystem;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.InputHandling.ClickHandler
+{
+    public class EntityDeselectedEvent : INetworkedEvent
+    {
+        public bool CanBeRaisedByClient => true;
+
+        public void Deserialise(BinaryReader reader)
+        { }
+
+        public void Serialise(BinaryWriter writer)
+        { }
+
+        public int SerialisedLength()
+        {
+            return 0;
+        }
+
+    }
+}

--- a/CorgEng.InputHandling/ClickHandler/EntitySelectedEvent.cs
+++ b/CorgEng.InputHandling/ClickHandler/EntitySelectedEvent.cs
@@ -1,0 +1,32 @@
+﻿using CorgEng.GenericInterfaces.EntityComponentSystem;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.InputHandling.ClickHandler
+{
+    public class EntitySelectedEvent : INetworkedEvent
+    {
+
+        public bool CanBeRaisedByClient => true;
+
+        public void Deserialise(BinaryReader reader)
+        {
+            return;
+        }
+
+        public void Serialise(BinaryWriter writer)
+        {
+            return;
+        }
+
+        public int SerialisedLength()
+        {
+            return 0;
+        }
+
+    }
+}

--- a/CorgEng.InputHandling/ClickHandler/WorldClickHandler.cs
+++ b/CorgEng.InputHandling/ClickHandler/WorldClickHandler.cs
@@ -1,9 +1,12 @@
 ﻿using CorgEng.Core;
 using CorgEng.Core.Dependencies;
+using CorgEng.EntityComponentSystem.Events;
 using CorgEng.EntityComponentSystem.Events.Events;
+using CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRendering;
 using CorgEng.EntityComponentSystem.Systems;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Logging;
+using CorgEng.GenericInterfaces.Rendering.Icons;
 using CorgEng.GenericInterfaces.UtilityTypes;
 using CorgEng.GenericInterfaces.World;
 using CorgEng.InputHandling.Events;
@@ -27,6 +30,9 @@ namespace CorgEng.InputHandling.ClickHandler
         [UsingDependency]
         private static IWorld World;
 
+        [UsingDependency]
+        private static IIconFactory IconFactory;
+
         //Track the last clicked location for cyclical selection of entities
         private static int lastClickedX = 0;
         private static int lastClickedY = 0;
@@ -34,11 +40,13 @@ namespace CorgEng.InputHandling.ClickHandler
 
         public override EntitySystemFlags SystemFlags => EntitySystemFlags.CLIENT_SYSTEM;
 
-        private SelectedComponent currentSelectedComponent;
-        private IEntity selectedEntity;
+        private static IIcon selectorOverlay;
+        private static SelectedComponent currentSelectedComponent;
+        private static IEntity selectedEntity;
 
         public override void SystemSetup()
         {
+            selectorOverlay = IconFactory.CreateIcon("selector");
             RegisterLocalEvent<SelectedComponent, ComponentAddedEvent>(OnComponentAdded);
             RegisterLocalEvent<SelectedComponent, ComponentRemovedEvent>(OnComponentRemoved);
         }
@@ -46,6 +54,8 @@ namespace CorgEng.InputHandling.ClickHandler
         private void OnComponentAdded(IEntity entity, SelectedComponent selectedComponent, ComponentAddedEvent componentAddedEvent)
         {
             if (componentAddedEvent.Component != selectedComponent)
+                return;
+            if (selectedEntity == entity)
                 return;
             //Unselect the existing entity
             if (selectedEntity != null)
@@ -55,6 +65,10 @@ namespace CorgEng.InputHandling.ClickHandler
             //Select this one
             selectedEntity = entity;
             currentSelectedComponent = selectedComponent;
+            //Call selection event
+            new EntitySelectedEvent().Raise(entity);
+            //Add an overlay
+            new AddOverlayEvent(selectorOverlay).Raise(entity);
         }
 
         private void OnComponentRemoved(IEntity entity, SelectedComponent selectedComponent, ComponentRemovedEvent componentRemovedEvent)
@@ -62,6 +76,8 @@ namespace CorgEng.InputHandling.ClickHandler
             //Not the correct component removed
             if (componentRemovedEvent.Component != selectedComponent)
                 return;
+            new EntityDeselectedEvent().Raise(entity);
+            new RemoveOverlayEvent(selectorOverlay).Raise(entity);
             //Deselect
             if (selectedEntity == entity)
             {
@@ -81,12 +97,17 @@ namespace CorgEng.InputHandling.ClickHandler
         /// </summary>
         public static void HandleWorldClick(MouseReleaseEvent releaseEvent, float windowWidth, float windowHeight)
         {
+            if (selectedEntity != null)
+            {
+                selectedEntity.RemoveComponent(currentSelectedComponent, false);
+            }
             //Transform the clicked position into world position
             IVector<float> clickedLocation = CorgEngMain.MainCamera.ScreenToWorldCoordinates(releaseEvent.CursorX * 2 - 1, releaseEvent.CursorY * 2 - 1, windowWidth, windowHeight);
             //Locate the world position that the mouse is currently over
             int clickedTileX = (int)Math.Round(clickedLocation.X);
             int clickedTileY = (int)Math.Round(clickedLocation.Y);
             //Check what we actually pressed on
+            Logger.WriteLine($"{clickedLocation}");
             //Determine our click mode
             //If we clicked on a different tile, reset the last contents index
             if (lastClickedX != clickedTileX || lastClickedY != clickedTileY || contentEnumerator == null)

--- a/CorgEng.InputHandling/InputHandler.cs
+++ b/CorgEng.InputHandling/InputHandler.cs
@@ -78,7 +78,7 @@ namespace CorgEng.InputHandling
                     mouseReleaseEvent.HeldTime = CorgEngMain.Time - mouseDownAt;
                     //Raise synchronously, so we can determine if the event was handled
                     mouseReleaseEvent.RaiseGlobally(true);
-                    if (!mouseReleaseEvent.Handled)
+                    if (!mouseReleaseEvent.Handled && mouseReleaseEvent.MouseButton == MouseButton.Left)
                     {
                         WorldClickHandler.HandleWorldClick(mouseReleaseEvent, CorgEngMain.GameWindow.Width, CorgEngMain.GameWindow.Height);
                     }

--- a/CorgEng.Rendering/Cameras/Isometic/IsometricCamera.cs
+++ b/CorgEng.Rendering/Cameras/Isometic/IsometricCamera.cs
@@ -37,7 +37,7 @@ namespace CorgEng.Rendering.Cameras.Isometic
             float widthMultiplier = (windowHeight / windowWidth) * (1.0f / (Width * 0.5f));
             float heightMultiplier = 1.0f / (Height * 0.5f);
             //Scale the X and Y
-            float worldX = (float)(x / widthMultiplier) - X;
+            float worldX = (float)(x / widthMultiplier) + X;
             float worldY = (float)(y / heightMultiplier) - Y;
             return new Vector<float>(worldX, -worldY);
         }


### PR DESCRIPTION
Adds in events when objects are selected/deselected.
Fixes X axis being inverted on the camera, breaking world click.
Selection only works on left click now.