### PR TITLE
Adds in instance to content loading

### DIFF
--- a/CorgEng.ContentLoading/DefinitionNodes/ComponentNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ComponentNode.cs
@@ -23,10 +23,11 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
             }
         }
 
-        public override object CreateInstance(object parent)
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
         {
-            IComponent createdComponent = base.CreateInstance(parent) as IComponent;
-
+            //Create the component
+            IComponent createdComponent = base.CreateInstance(parent, instanceRefs) as IComponent;
+            //Add the compoennt
             IEntity parentEntity = parent as IEntity;
             parentEntity.AddComponent(createdComponent);
             return createdComponent;

--- a/CorgEng.ContentLoading/DefinitionNodes/DefinitionNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/DefinitionNode.cs
@@ -12,6 +12,8 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
 
         public List<DefinitionNode> Children { get; } = new List<DefinitionNode>();
 
+        protected string? Key { get; private set; }
+
         public DefinitionNode(DefinitionNode parent)
         {
             parent?.Children.Add(this);
@@ -21,13 +23,16 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
         /// Parse the node
         /// </summary>
         /// <param name="node"></param>
-        public abstract void ParseSelf(XmlNode node);
+        public virtual void ParseSelf(XmlNode node)
+        {
+            Key = node.Attributes["key"]?.Value;
+        }
 
         /// <summary>
         /// Called when the instance needs to be created
         /// </summary>
         /// <returns></returns>
-        public abstract object CreateInstance(object parent);
+        public abstract object CreateInstance(object parent, Dictionary<string, object> instanceRefs);
 
     }
 }

--- a/CorgEng.ContentLoading/DefinitionNodes/EntityNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/EntityNode.cs
@@ -35,6 +35,8 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
 
         public override void ParseSelf(XmlNode node)
         {
+            //Perform base parsing actions
+            base.ParseSelf(node);
             Name = node.Attributes["name"].Value;
             Abstract = node.Attributes["abstract"]?.Value.ToLower() == "true";
             EntityCreator.EntityNodesByName.Add(Name, this);
@@ -46,16 +48,21 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
         /// <returns></returns>
         public IEntity CreateEntity()
         {
-            return (IEntity)CreateInstance(null);
+            return (IEntity)CreateInstance(null, new Dictionary<string, object>());
         }
 
-        public override object CreateInstance(object parent)
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
         {
             IEntity createdEntity = EntityFactory.CreateEmptyEntity();
+            //Store the key
+            if (Key != null)
+            {
+                instanceRefs.Add(Key, createdEntity);
+            }
             //Add on properties
             foreach (DefinitionNode childNode in Children)
             {
-                childNode.CreateInstance(createdEntity);
+                childNode.CreateInstance(createdEntity, instanceRefs);
             }
             return createdEntity;
         }

--- a/CorgEng.ContentLoading/DefinitionNodes/InstanceNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/InstanceNode.cs
@@ -1,0 +1,34 @@
+﻿using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace CorgEng.ContentLoading.DefinitionNodes
+{
+    internal class InstanceNode : DefinitionNode
+    {
+
+        private string referenceName;
+
+        public InstanceNode(DefinitionNode parent) : base(parent)
+        {
+        }
+
+        public override void ParseSelf(XmlNode node)
+        {
+            //Do generic parsing
+            base.ParseSelf(node);
+            //Get reference name
+            referenceName = node.InnerText.Trim();
+        }
+
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
+        {
+            return instanceRefs[referenceName];
+        }
+
+    }
+}

--- a/CorgEng.ContentLoading/DefinitionNodes/ObjectNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ObjectNode.cs
@@ -21,6 +21,8 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
 
         public override void ParseSelf(XmlNode node)
         {
+            //Perform base parsing actions
+            base.ParseSelf(node);
             string typeName = node.Attributes["type"].Value;
             if (!EntityLoader.TypePaths.ContainsKey(typeName))
             {
@@ -29,14 +31,19 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
             ObjectType = EntityLoader.TypePaths[typeName];
         }
 
-        public override object CreateInstance(object parent)
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
         {
             //Create ourself
             object createdObject = Activator.CreateInstance(ObjectType);
+            //Store it
+            if (Key != null)
+            {
+                instanceRefs.Add(Key, createdObject);
+            }
             //Pass ourself to our children
             foreach (DefinitionNode childNode in Children)
             {
-                childNode.CreateInstance(createdObject);
+                childNode.CreateInstance(createdObject, instanceRefs);
             }
             //Return the created object
             return createdObject;

--- a/CorgEng.ContentLoading/DefinitionNodes/PropertyNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/PropertyNode.cs
@@ -38,6 +38,8 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
 
         public override void ParseSelf(XmlNode node)
         {
+            //Perform base parsing actions
+            base.ParseSelf(node);
             //Get the property that we effect
             TargetProperty = ObjectParent.ObjectType.GetProperty(node.Attributes["name"].Value);
             //Determine our property value
@@ -54,20 +56,32 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
             }
         }
 
-        public override object CreateInstance(object parent)
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
         {
             if (PropertyValue != null)
             {
                 TargetProperty.SetValue(parent, PropertyValue);
+                if (Key != null)
+                {
+                    instanceRefs.Add(Key, PropertyValue);
+                }
             }
             else if (Children[0] is ObjectNode childNode)
             {
-                object createdObject = childNode.CreateInstance(null);
+                object createdObject = childNode.CreateInstance(null, instanceRefs);
+                if (Key != null)
+                {
+                    instanceRefs.Add(Key, createdObject);
+                }
                 TargetProperty.SetValue(parent, createdObject);
             }
             else if (Children[0] is DependencyNode dependencyNode)
             {
-                object createdObject = dependencyNode.CreateInstance(null);
+                object createdObject = dependencyNode.CreateInstance(null, instanceRefs);
+                if (Key != null)
+                {
+                    instanceRefs.Add(Key, createdObject);
+                }
                 TargetProperty.SetValue(parent, createdObject);
             }
             else

--- a/CorgEng.ContentLoading/EntityLoader.cs
+++ b/CorgEng.ContentLoading/EntityLoader.cs
@@ -87,6 +87,9 @@ namespace CorgEng.ContentLoading
                 case "dependency":
                     createdNode = new DependencyNode(parentNode);
                     break;
+                case "instance":
+                    createdNode = new InstanceNode(parentNode);
+                    break;
                 default:
                     Logger?.WriteLine($"Unknown node in entitiy definition file: {node.Name}.", LogType.ERROR);
                     return;

--- a/CorgEng.ContentLoading/README.md
+++ b/CorgEng.ContentLoading/README.md
@@ -1,0 +1,110 @@
+﻿
+## ContentLoading V2 Documentation
+
+## Summary
+
+Version 2 of the content loading system for CorgEng will incorporate better XML design and standardise some of the things we were doing weirdly before.
+
+## Nodes
+
+### All Nodes
+
+#### Properties
+
+ - key: May assign the instance a key identifier, which can then be used by children.
+If an entity is given a key, then the created entity instance can be used as a parameter.
+
+### Entities
+
+The parent node of the entity file.
+
+### Entity
+
+Specifies the definition of a new entity.
+
+#### Attributes:
+
+ - name: Specifies the unique name to use for this entity.
+ - abstract: A boolean value representing if this entity can be spawned in the world or not.
+ - parent: The name of the parent entity. Values from the parent will be inhereted.
+
+#### Content:
+
+ - Can contain 'Component' nodes.
+
+---
+
+### Component
+
+Adds a component to an entity.
+
+#### Attributes:
+
+ - type: The type of the component to add.
+
+#### Content:
+
+ - Can contain 'Property' nodes. This will update the properties of the component.
+
+---
+
+### Property
+
+Updates the property of the parent type.
+
+#### Attributes:
+
+ - name: The name of the property to set.
+ - value (optional): If this is set then it will apply the value specified in the attribute to the property.
+
+#### Content:
+
+ - Can contain 'Property' nodes. This will affect the assigned value of this property, which will usually be the default value, unless already specified.
+ - Can contain 'Object' nodes. This will create a new object and replace the default value of the property.
+
+### Object
+
+Creates a new object from a specified type. Can be used to create entities if the name attribute is used instead of the type.
+
+#### Attributes:
+
+ - name: If set, will locate and spawn the entity with this name.
+ - type: If set, will create an object of the specified type.
+
+#### Content:
+
+ - Can contain 'Property' nodes.
+
+### Instance
+
+Fetches the created instance based on a key.
+
+## Sample File
+
+```xml=
+<?xml version="1.0" encoding="utf-8" ?> 
+<Entities>
+
+  <Entity name="Pawn">
+
+    <Component type="TransformComponent" />
+    
+    <Component type="SpriteRenderComponent">
+      <Property name="Sprite">
+        <Dependency type="IIconFactory" method="CreateIcon">
+          <Parameter>human_body</Parameter>
+        </Dependency>
+      </Property>
+    </Component>
+    
+    <Component type="MobHealthComponent">
+      <Property name="MaxHealth">100</Property>
+      <Property name="Health">100</Property>
+    </Component>
+
+    <Component type="PawnControlComponent" />
+    
+  </Entity>
+  
+</Entities>
+```


### PR DESCRIPTION
Add in the Instance node into content loading.
This allows instances of an object to be passed into parameters in dependency nodes, rather than strictly static data types. If a factory method requires a reference to the entity it is creating something for, that is now possible.

An example of use:

The behaviour manager requires a reference to the object it will be applied to, which can be used with the key parameters and instance node.

```xml
<?xml version="1.0" encoding="utf-8" ?> 
<Entities>

  <Entity name="Pawn" key="pawn">
    
    <Component type="PawnBehaviourComponent">
      <Property name="BehaviourManager">
        <Dependency type="IBehaviourManagerFactory" method="CreateBehaviourManager">
          <Parameter>
            <Instance>pawn</Instance>
          </Parameter>
        </Dependency>
      </Property>
    </Component>
    
  </Entity>
  
</Entities>

```