### PR TITLE
Fixes pathfinding failing if the end/start is a float

### DIFF
--- a/CorgEng.GenericInterfaces/Pathfinding/IPathfindingRequest.cs
+++ b/CorgEng.GenericInterfaces/Pathfinding/IPathfindingRequest.cs
@@ -12,7 +12,7 @@ namespace CorgEng.GenericInterfaces.Pathfinding
 
         IVector<float> Start { get; }
 
-        IVector<float> End { get; }
+        IVector<int> End { get; }
 
         /// <summary>
         /// Lets us query if we can enter a specified cell.

--- a/CorgEng.Pathfinding/Pathfinding/PathfinderNode.cs
+++ b/CorgEng.Pathfinding/Pathfinding/PathfinderNode.cs
@@ -42,12 +42,13 @@ namespace CorgEng.Pathfinding.Pathfinding
         /// </summary>
         public Vector<int> Position { get; set; }
 
-        public PathfinderNode(PathfinderNode? source, Vector<int> position, float sourceDistance, Vector<float> destination)
+        public PathfinderNode(PathfinderNode? source, Vector<int> position, float sourceDistance, Vector<int> destination)
         {
             Source = source;
             SourceDistance = sourceDistance;
             EndDistance = QuickDistance(position, destination);
             Position = position;
+            Console.WriteLine(position);
         }
 
         public IPath CompilePath()

--- a/CorgEng.Pathfinding/Pathfinding/PathfindingQueue.cs
+++ b/CorgEng.Pathfinding/Pathfinding/PathfindingQueue.cs
@@ -47,7 +47,7 @@ namespace CorgEng.Pathfinding.Pathfinding
         /// <param name="position"></param>
         /// <param name="newDistance"></param>
         /// <param name="newSource"></param>
-        public void UpdateNode(Vector<float> position, float newDistance, PathfinderNode? newSource, IPathfindingRequest request)
+        public void UpdateNode(Vector<int> position, float newDistance, PathfinderNode? newSource, IPathfindingRequest request)
         {
             if (nodeLookup.ContainsKey(position))
             {
@@ -81,7 +81,7 @@ namespace CorgEng.Pathfinding.Pathfinding
             else
             {
                 //A new node was created
-                PathfinderNode createdNode = new PathfinderNode(newSource, position, newDistance, (Vector<float>)request.End);
+                PathfinderNode createdNode = new PathfinderNode(newSource, position, newDistance, (Vector<int>)request.End);
                 //Add the reference to this node
                 nodeLookup.Add(position, createdNode);
                 //Add the node to the new position in the queue

--- a/CorgEng.Pathfinding/Pathfinding/PathfindingRequest.cs
+++ b/CorgEng.Pathfinding/Pathfinding/PathfindingRequest.cs
@@ -13,7 +13,7 @@ namespace CorgEng.Pathfinding.Pathfinding
     {
         public IVector<float> Start { get; set; }
 
-        public IVector<float> End { get; set; }
+        public IVector<int> End { get; set; }
 
         public IPathCellQueryer PathCellQueryer { get; set; }
 
@@ -21,14 +21,14 @@ namespace CorgEng.Pathfinding.Pathfinding
 
         public PathFailedDelegate OnPathFailed { get; set; }
 
-        public PathfindingRequest(IVector<float> start, IVector<float> end, IPathCellQueryer pathCellQueryer)
+        public PathfindingRequest(IVector<float> start, IVector<int> end, IPathCellQueryer pathCellQueryer)
         {
             Start = start;
             End = end;
             PathCellQueryer = pathCellQueryer;
         }
 
-        public PathfindingRequest(IVector<float> start, IVector<float> end, IPathCellQueryer pathCellQueryer, PathFoundDelegate onPathFound)
+        public PathfindingRequest(IVector<float> start, IVector<int> end, IPathCellQueryer pathCellQueryer, PathFoundDelegate onPathFound)
         {
             Start = start;
             End = end;
@@ -36,7 +36,7 @@ namespace CorgEng.Pathfinding.Pathfinding
             OnPathFound = onPathFound;
         }
 
-        public PathfindingRequest(IVector<float> start, IVector<float> end, IPathCellQueryer pathCellQueryer, PathFoundDelegate onPathFound, PathFailedDelegate onPathFailed)
+        public PathfindingRequest(IVector<float> start, IVector<int> end, IPathCellQueryer pathCellQueryer, PathFoundDelegate onPathFound, PathFailedDelegate onPathFailed)
         {
             Start = start;
             End = end;

--- a/CorgEng.Pathfinding/Pathfinding/PathfindingRequestFactory.cs
+++ b/CorgEng.Pathfinding/Pathfinding/PathfindingRequestFactory.cs
@@ -1,6 +1,7 @@
 ﻿using CorgEng.DependencyInjection.Dependencies;
 using CorgEng.GenericInterfaces.Pathfinding;
 using CorgEng.GenericInterfaces.UtilityTypes;
+using CorgEng.UtilityTypes.Vectors;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,17 +16,17 @@ namespace CorgEng.Pathfinding.Pathfinding
 
         public IPathfindingRequest CreateRequest(IVector<float> start, IVector<float> end, IPathCellQueryer pathCellQueryer)
         {
-            return new PathfindingRequest(start, end, pathCellQueryer);
+            return new PathfindingRequest(start, (Vector<int>)(Vector<float>)end, pathCellQueryer);
         }
 
         public IPathfindingRequest CreateRequest(IVector<float> start, IVector<float> end, IPathCellQueryer pathCellQueryer, PathFoundDelegate onPathFound)
         {
-            return new PathfindingRequest(start, end, pathCellQueryer, onPathFound);     
+            return new PathfindingRequest(start, (Vector<int>)(Vector<float>)end, pathCellQueryer, onPathFound);     
         }
 
         public IPathfindingRequest CreateRequest(IVector<float> start, IVector<float> end, IPathCellQueryer pathCellQueryer, PathFoundDelegate onPathFound, PathFailedDelegate onPathFailed)
         {
-            return new PathfindingRequest(start, end, pathCellQueryer, onPathFound, onPathFailed);
+            return new PathfindingRequest(start, (Vector<int>)(Vector<float>)end, pathCellQueryer, onPathFound, onPathFailed);
         }
 
     }

--- a/CorgEng.Pathfinding/Pathfinding/PathfindingRun.cs
+++ b/CorgEng.Pathfinding/Pathfinding/PathfindingRun.cs
@@ -33,7 +33,7 @@ namespace CorgEng.Pathfinding.Pathfinding
         {
             request = pathfindingRequest;
             //Add the first node
-            PathfinderNode initialNode = new PathfinderNode(null, (Vector<int>)(Vector<float>)request.Start, 0, (Vector<float>)request.End);
+            PathfinderNode initialNode = new PathfinderNode(null, (Vector<float>)request.Start, 0, (Vector<int>)request.End);
             examinationQueue.UpdateNode((Vector<float>)request.Start, 0, null, request);
             //Do processing until we can no longer process
             while (examinationQueue.HasNodes())

--- a/CorgEng.Tests/Pathfinding/PathfindingTests.cs
+++ b/CorgEng.Tests/Pathfinding/PathfindingTests.cs
@@ -35,6 +35,9 @@ namespace CorgEng.Tests.Pathfinding
         [UsingDependency]
         private static ILogger Logger;
 
+        [UsingDependency]
+        private static IPathfindingRequestFactory PathfindingRequestFactory;
+
         /// <summary>
         /// Test a simple path
         /// </summary>
@@ -42,7 +45,7 @@ namespace CorgEng.Tests.Pathfinding
         [Timeout(5000)]
         public async Task TestSimplePath()
         {
-            PathfindingRequest pathfindingRequest = new PathfindingRequest(
+            IPathfindingRequest pathfindingRequest = PathfindingRequestFactory.CreateRequest(
                 new Vector<float>(0, 0),
                 new Vector<float>(0, 10),
                 new PathfindingTestQueryer(),
@@ -60,7 +63,7 @@ namespace CorgEng.Tests.Pathfinding
         [Timeout(5000)]
         public async Task TestDiagonalPath()
         {
-            PathfindingRequest pathfindingRequest = new PathfindingRequest(
+            IPathfindingRequest pathfindingRequest = PathfindingRequestFactory.CreateRequest(
                 new Vector<float>(0, 0),
                 new Vector<float>(10, 10),
                 new PathfindingTestQueryer(),
@@ -86,9 +89,27 @@ namespace CorgEng.Tests.Pathfinding
 
         [TestMethod]
         [Timeout(5000)]
+        public async Task TestFloatPositions()
+        {
+            IPathfindingRequest pathfindingRequest = PathfindingRequestFactory.CreateRequest(
+                new Vector<float>(0.1f, 0.3f),
+                new Vector<float>(10.2f, -10.6f),
+                new PathfindingWallTestQueryer(),
+                (path) => { },
+                () => {
+                    Assert.Fail("Pathfinding failed");
+                }
+                );
+            IPath foundPath = await Pathfinder.GetPath(pathfindingRequest);
+            Assert.IsNotNull(foundPath);
+            Logger.WriteLine(foundPath);
+        }
+
+        [TestMethod]
+        [Timeout(5000)]
         public async Task TestWallPath()
         {
-            PathfindingRequest pathfindingRequest = new PathfindingRequest(
+            IPathfindingRequest pathfindingRequest = PathfindingRequestFactory.CreateRequest(
                 new Vector<float>(0, 0),
                 new Vector<float>(10, -10),
                 new PathfindingWallTestQueryer(),


### PR DESCRIPTION
Pathfinding will no longer fail to notice that it has reached the end for float path endings.