### PR TITLE
Adds in content loading arrays

### DIFF
--- a/CorgEng.ContentLoading/DefinitionNodes/ArrayNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ArrayNode.cs
@@ -1,0 +1,49 @@
+﻿using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace CorgEng.ContentLoading.DefinitionNodes
+{
+    internal class ArrayNode : DefinitionNode
+    {
+
+        //Get the type of the array
+        Type arrayType;
+
+        public ArrayNode(DefinitionNode parent) : base(parent)
+        {
+        }
+
+        public override void ParseSelf(XmlNode node)
+        {
+            //Perform base parsing actions
+            base.ParseSelf(node);
+            //Get the array type
+            arrayType = EntityLoader.TypePaths[node.Attributes["type"].Value];
+        }
+
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
+        {
+            //Create the array object
+            Array createdArray = Array.CreateInstance(arrayType, Children.Count);
+            //Populate the array
+            int i = 0;
+            foreach (DefinitionNode child in Children)
+            {
+                createdArray.SetValue(child.CreateInstance(createdArray, instanceRefs), i++);
+            }
+            //Add a reference to the created array
+            if (Key != null)
+            {
+                instanceRefs.Add(Key, createdArray);
+            }
+            //return the array
+            return createdArray;
+        }
+
+    }
+}

--- a/CorgEng.ContentLoading/DefinitionNodes/DependencyNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/DependencyNode.cs
@@ -28,8 +28,6 @@ namespace CorgEng.ContentLoading.DefinitionNodes
         /// </summary>
         private MethodInfo methodToCall;
 
-        private string[] dynamicKeys;
-
         private bool[] isDynamic;
 
         private bool hasDynamicParams = false;
@@ -64,7 +62,6 @@ namespace CorgEng.ContentLoading.DefinitionNodes
             //Get the parameters
             parameters = new object[node.ChildNodes.Count];
             isDynamic = new bool[node.ChildNodes.Count];
-            dynamicKeys = new string[node.ChildNodes.Count];
             for (int i = 0; i < node.ChildNodes.Count; i ++)
             {
                 //Parse the static value of the node
@@ -75,10 +72,8 @@ namespace CorgEng.ContentLoading.DefinitionNodes
                 //Mark the node as dynamic
                 else
                 {
-                    //TODO: Allow for dynamic object parameters
                     hasDynamicParams = true;
                     isDynamic[i] = true;
-                    dynamicKeys[i] = node.FirstChild.InnerText.Trim();
                 }
             }
         }
@@ -92,7 +87,7 @@ namespace CorgEng.ContentLoading.DefinitionNodes
                 {
                     if (isDynamic[i])
                     {
-                        parameters[i] = instanceRefs[dynamicKeys[i]];
+                        parameters[i] = Children[i].CreateInstance(parent, instanceRefs);
                     }
                 }
             }

--- a/CorgEng.ContentLoading/DefinitionNodes/ElementNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ElementNode.cs
@@ -1,0 +1,62 @@
+﻿using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace CorgEng.ContentLoading.DefinitionNodes
+{
+    internal class ElementNode : DefinitionNode
+    {
+
+        /// <summary>
+        /// The value to apply, unless we contain an object node as a child
+        /// </summary>
+        public object PropertyValue { get; protected set; }
+
+        public ElementNode(DefinitionNode parent) : base(parent)
+        {
+        }
+
+        public override void ParseSelf(XmlNode node)
+        {
+            //Perform base parsing actions
+            base.ParseSelf(node);
+        }
+
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
+        {
+            object propertyValue = GetValue(parent, instanceRefs);
+            if (Key != null)
+            {
+                instanceRefs.Add(Key, propertyValue);
+            }
+            return propertyValue;
+        }
+
+        private object GetValue(object parent, Dictionary<string, object> instanceRefs)
+        {
+            if (PropertyValue != null)
+            {
+                return PropertyValue;
+            }
+            else if (Children[0] is ObjectNode childNode)
+            {
+                object createdObject = childNode.CreateInstance(null, instanceRefs);
+                return createdObject;
+            }
+            else if (Children[0] is DependencyNode dependencyNode)
+            {
+                object createdObject = dependencyNode.CreateInstance(null, instanceRefs);
+                return createdObject;
+            }
+            else
+            {
+                throw new Exception("Failed to set array node, invalid value.");
+            }
+        }
+
+    }
+}

--- a/CorgEng.ContentLoading/DefinitionNodes/ParameterNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ParameterNode.cs
@@ -1,0 +1,27 @@
+﻿using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.ContentLoading.DefinitionNodes
+{
+    internal class ParameterNode : DefinitionNode
+    {
+        public ParameterNode(DefinitionNode parent) : base(parent)
+        {
+        }
+
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
+        {
+            object created = Children.First().CreateInstance(parent, instanceRefs);
+            if (Key != null)
+            {
+                instanceRefs.Add(Key, created);
+            }
+            return created;
+        }
+
+    }
+}

--- a/CorgEng.ContentLoading/EntityLoader.cs
+++ b/CorgEng.ContentLoading/EntityLoader.cs
@@ -72,6 +72,9 @@ namespace CorgEng.ContentLoading
                 case "entities":
                     createdNode = null;
                     break;
+                case "parameter":
+                    createdNode = new ParameterNode(parentNode);
+                    break;
                 case "entity":
                     createdNode = new EntityNode(parentNode);
                     break;
@@ -89,6 +92,12 @@ namespace CorgEng.ContentLoading
                     break;
                 case "instance":
                     createdNode = new InstanceNode(parentNode);
+                    break;
+                case "array":
+                    createdNode = new ArrayNode(parentNode);
+                    break;
+                case "element":
+                    createdNode = new ElementNode(parentNode);
                     break;
                 default:
                     Logger?.WriteLine($"Unknown node in entitiy definition file: {node.Name}.", LogType.ERROR);

--- a/CorgEng.ContentLoading/README.md
+++ b/CorgEng.ContentLoading/README.md
@@ -62,6 +62,8 @@ Updates the property of the parent type.
  - Can contain 'Property' nodes. This will affect the assigned value of this property, which will usually be the default value, unless already specified.
  - Can contain 'Object' nodes. This will create a new object and replace the default value of the property.
 
+---
+
 ### Object
 
 Creates a new object from a specified type. Can be used to create entities if the name attribute is used instead of the type.
@@ -78,6 +80,52 @@ Creates a new object from a specified type. Can be used to create entities if th
 ### Instance
 
 Fetches the created instance based on a key.
+
+---
+
+### Array
+
+Defines a collection of elements stored in an Array object.
+Requires a type to be specified - The type is not automatically inferred.
+
+#### Content:
+
+ - Can contain Element nodes
+
+#### Example
+
+An array of value types:
+
+```xml
+<Array type="Int32">
+    <Element>4</Element>
+    <Element>8</Element>
+    <Element>30</Element>
+    ...
+</Array>
+```
+
+An array of complex types:
+
+```xml
+<Array type="ComplexType">
+    <Element>
+        <Object type="ComplexType">
+            ...
+        </Object>
+    </Element>
+    ...
+</Array>
+```
+
+---
+
+### Element
+
+Defines an element of a collection type.
+Can either be a value type, or a complex type.
+
+---
 
 ## Sample File
 


### PR DESCRIPTION
Content loadnig now supports arrays

### Array

Defines a collection of elements stored in an Array object.
Requires a type to be specified - The type is not automatically inferred.

#### Content:

 - Can contain Element nodes

#### Example

An array of value types:

```xml
<Array type="Int32">
    <Element>4</Element>
    <Element>8</Element>
    <Element>30</Element>
    ...
</Array>
```

An array of complex types:

```xml
<Array type="ComplexType">
    <Element>
        <Object type="ComplexType">
            ...
        </Object>
    </Element>
    ...
</Array>
```

---

### Element

Defines an element of a collection type.
Can either be a value type, or a complex type.

---