### PR TITLE
Synchronous mouse events

### DIFF
--- a/CorgEng.Core/CorgEngMain.cs
+++ b/CorgEng.Core/CorgEngMain.cs
@@ -1,4 +1,4 @@
-﻿#define PERFORMANCE
+﻿//#define PERFORMANCE
 
 using CorgEng.Core.Dependencies;
 using CorgEng.Core.Modules;

--- a/CorgEng.Core/CorgEngMain.cs
+++ b/CorgEng.Core/CorgEngMain.cs
@@ -1,4 +1,6 @@
-﻿using CorgEng.Core.Dependencies;
+﻿#define PERFORMANCE
+
+using CorgEng.Core.Dependencies;
 using CorgEng.Core.Modules;
 using CorgEng.Core.Rendering;
 using CorgEng.Core.Rendering.Exceptions;
@@ -111,6 +113,10 @@ namespace CorgEng.Core
         /// </summary>
         public static void TransferToRenderingThread()
         {
+#if PERFORMANCE
+            int i = 0;
+            double total = 0;
+#endif
             //While the window shouldn't close
             while (!GameWindow.ShouldClose())
             {
@@ -129,6 +135,17 @@ namespace CorgEng.Core
                 //Pass the output image from the render core to the internal renderer
                 InternalRenderMaster.RenderImageToScreen(MainRenderCore);
                 DeltaTime = Glfw.Time - lastFrameTime;
+#if PERFORMANCE
+                total += DeltaTime;
+                i++;
+                if (i >= 200)
+                {
+                    total /= i;
+                    Logger.WriteLine($"Average delta time: {total} seconds Avg FPS: ({1/total})", LogType.TEMP);
+                    i = 0;
+                    total = 0;
+                }
+#endif
             }
         }
 

--- a/CorgEng.InputHandling/InputHandler.cs
+++ b/CorgEng.InputHandling/InputHandler.cs
@@ -51,12 +51,16 @@ namespace CorgEng.InputHandling
 
         private void HandleScroll(IntPtr window, double x, double y)
         {
-            new MouseScrollEvent(y).RaiseGlobally();
+            //Synchronous to prevent subsystem overloading, will not render the
+            //next frame until this is handled.
+            new MouseScrollEvent(y).RaiseGlobally(synchronous: true);
         }
 
         private void HandleCursorMove(IntPtr window, double x, double y)
         {
-            new MouseMoveEvent(x, y).RaiseGlobally();
+            //Synchronous to prevent subsystem overloading, will not render the
+            //next frame until this is handled.
+            new MouseMoveEvent(x, y).RaiseGlobally(synchronous: true);
         }
 
         private double mouseDownAt = 0;


### PR DESCRIPTION
Mouse events are now synchronous. This means that the next frame will not render until the mouse events are handled (if they are registered).
This will prevent subsystems from being overloaded if the renderer is running faster than the entity system can handle things.
Also adds in an FPS counter on the renderer if a define is defined.