### PR TITLE
Exceptions will no longer freeze synchronous events, some minor mouse event changes.

### DIFF
--- a/CorgEng.InputHandling/InputHandler.cs
+++ b/CorgEng.InputHandling/InputHandler.cs
@@ -60,7 +60,7 @@ namespace CorgEng.InputHandling
         {
             //Synchronous to prevent subsystem overloading, will not render the
             //next frame until this is handled.
-            new MouseMoveEvent(x, y).RaiseGlobally(synchronous: true);
+            new MouseMoveEvent(x / CorgEngMain.GameWindow.Width, y / CorgEngMain.GameWindow.Height).RaiseGlobally(synchronous: true);
         }
 
         private double mouseDownAt = 0;

--- a/CorgEng.Tests/ExperimentationTests.cs
+++ b/CorgEng.Tests/ExperimentationTests.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CorgEng.Tests
+{
+    /// <summary>
+    /// Class for experimenting with C# features
+    /// </summary>
+    [TestClass]
+    public class ExperimentationTests
+    {
+
+        [TestMethod]
+        [Timeout(1000)]
+        public void TestAutoWaitHandler()
+        {
+            for (int i = 0; i < 100; i++)
+            {
+                AutoResetEvent synchronousWaitEvent = new AutoResetEvent(false);
+                synchronousWaitEvent.Set();
+                synchronousWaitEvent.WaitOne();
+            }
+        }
+
+    }
+}

--- a/CorgEng.UserInterface/Hooks/UserInterfaceClickHook.cs
+++ b/CorgEng.UserInterface/Hooks/UserInterfaceClickHook.cs
@@ -32,10 +32,10 @@ namespace CorgEng.UserInterface.Hooks
         {
             foreach (UserInterfaceComponent component in ScreencastingComopnents)
             {
-                if (component.Screencast((int)(CorgEngMain.GameWindow.Width * x), (int)(CorgEngMain.GameWindow.Height * (1 - y))) is UserInterfaceBox)
+                if (component.Screencast((int)(CorgEngMain.GameWindow.Width * x), (int)(CorgEngMain.GameWindow.Height * (1 - y))) is UserInterfaceBox clickedBox)
                 {
                     //Send a clicked signal to the component
-                    new UserInterfaceClickEvent().Raise(component.ComponentHolder);
+                    new UserInterfaceClickEvent().Raise(clickedBox.ComponentHolder);
                     //Return true
                     return true;
                 }


### PR DESCRIPTION
An exception being thrown within a synchronous event will no longer cause that event to hang forever.
Fixes mouse events not being relative between 0 and 1.
Fixes user interface onClick hook not working.

The game could just freeze entirely if an exception occured as a result of a mouse movement event.