### PR TITLE
World tracking fixes

### DIFF
--- a/CorgEng.EntityComponentSystem/Implementations/Tracking/TrackComponent.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Tracking/TrackComponent.cs
@@ -1,5 +1,8 @@
-﻿using CorgEng.EntityComponentSystem.Implementations.Transform;
+﻿using CorgEng.EntityComponentSystem.Components;
+using CorgEng.EntityComponentSystem.Implementations.Transform;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.UtilityTypes;
+using CorgEng.GenericInterfaces.World;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,12 +11,8 @@ using System.Threading.Tasks;
 
 namespace CorgEng.World.Components
 {
-    public class TrackComponent : IComponent
+    public class TrackComponent : Component, IWorldTrackComponent
     {
-
-        public bool IsSynced => false;
-
-        public IEntity Parent { get; set; }
 
         public string Key { get; set; }
 
@@ -21,13 +20,17 @@ namespace CorgEng.World.Components
         /// Get the transform linked to this component
         /// </summary>
         private TransformComponent _storedTransform;
-        public TransformComponent Transform {
+        public virtual TransformComponent Transform {
             get {
                 if(_storedTransform == null)
                     _storedTransform = Parent.GetComponent<TransformComponent>();
                 return _storedTransform;
             }
         }
+
+        public int ContentsIndexPosition { get; set; } = -1;
+
+        public IVector<int> ContentsLocation { get; set; } = null;
 
         public TrackComponent(string key)
         {

--- a/CorgEng.EntityComponentSystem/Implementations/Transform/TransformComponent.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Transform/TransformComponent.cs
@@ -2,6 +2,7 @@
 using CorgEng.GenericInterfaces.ContentLoading;
 using CorgEng.GenericInterfaces.Networking.Attributes;
 using CorgEng.UtilityTypes.Vectors;
+using CorgEng.World.Components;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,15 +16,21 @@ namespace CorgEng.EntityComponentSystem.Implementations.Transform
     /// with different positions, scales or rotations.
     /// This component is not networked, for a networked transform variant, use
     /// NetworkedTransformComponent from CorgEng.Networking.
+    /// Inherets from trackcomponent.
     /// </summary>
-    public class TransformComponent : Component
+    public class TransformComponent : TrackComponent
     {
+
+        public TransformComponent() : base("_world")
+        { }
 
         /// <summary>
         /// Start with a zero value
         /// </summary>
         [NetworkSerialized(prototypeInclude = false)]
         public Vector<float> Position { get; internal set; } = new Vector<float>(0, 0);
+
+        public override TransformComponent Transform => this;
 
     }
 }

--- a/CorgEng.EntityComponentSystem/Systems/EntitySystem.cs
+++ b/CorgEng.EntityComponentSystem/Systems/EntitySystem.cs
@@ -269,7 +269,7 @@ namespace CorgEng.EntityComponentSystem.Systems
 
         private static IEnumerable<Type> TypeCache;
 
-        private Dictionary<object, SystemEventHandlerDelegate> _linkedHandlers = new Dictionary<object, SystemEventHandlerDelegate>();
+        private Dictionary<(Type, object), SystemEventHandlerDelegate> _linkedHandlers = new Dictionary<(Type, object), SystemEventHandlerDelegate>();
 
         /// <summary>
         /// Register to a local event
@@ -338,9 +338,9 @@ namespace CorgEng.EntityComponentSystem.Systems
                     };
                     lock (_linkedHandlers)
                     {
-                        if (_linkedHandlers.ContainsKey(eventHandler))
+                        if (_linkedHandlers.ContainsKey((typeToRegister, eventHandler)))
                             throw new Exception("Attempting to register an event that is already registered.");
-                        _linkedHandlers.Add(eventHandler, createdEventHandler);
+                        _linkedHandlers.Add((typeToRegister, eventHandler), createdEventHandler);
                     }
                     RegisteredSystemSignalHandlers[eventComponentPair].Add(createdEventHandler);
                 }
@@ -381,12 +381,12 @@ namespace CorgEng.EntityComponentSystem.Systems
                 {
                     lock (_linkedHandlers)
                     {
-                        if (!_linkedHandlers.ContainsKey(eventHandler))
+                        if (!_linkedHandlers.ContainsKey((typeToRegister, eventHandler)))
                         {
                             throw new Exception($"Attempting to unregister an event handler that isn't registered on {GetType()}.");
                         }
                         //Create and return an event handler so that it can be 
-                        RegisteredSystemSignalHandlers[eventComponentPair].Remove(_linkedHandlers[eventHandler]);
+                        RegisteredSystemSignalHandlers[eventComponentPair].Remove(_linkedHandlers[(typeToRegister, eventHandler)]);
                         if (RegisteredSystemSignalHandlers[eventComponentPair].Count == 0)
                         {
                             RegisteredSystemSignalHandlers.Remove(eventComponentPair);

--- a/CorgEng.GenericInterfaces/EntityComponentSystem/IEntity.cs
+++ b/CorgEng.GenericInterfaces/EntityComponentSystem/IEntity.cs
@@ -12,10 +12,6 @@ namespace CorgEng.GenericInterfaces.EntityComponentSystem
 
         List<IComponent> Components { get; }
 
-        int ContentsIndex { get; set; }
-
-        IVector<int> ContentsLocation { get; set; }
-
         uint Identifier { get; }
 
         void AddComponent(IComponent component);

--- a/CorgEng.GenericInterfaces/World/IContentsHolder.cs
+++ b/CorgEng.GenericInterfaces/World/IContentsHolder.cs
@@ -14,19 +14,19 @@ namespace CorgEng.GenericInterfaces.World
         /// Insert an element into this tile
         /// </summary>
         /// <param name="entity"></param>
-        void Insert(IEntity entity);
+        void Insert(IWorldTrackComponent entity);
 
         /// <summary>
         /// Remove an element from the world tile
         /// </summary>
         /// <param name="entity"></param>
-        void Remove(IEntity entity);
+        void Remove(IWorldTrackComponent entity);
 
         /// <summary>
         /// Get all the contents of this world tile
         /// </summary>
         /// <returns></returns>
-        IEnumerable<IEntity> GetContents();
+        IEnumerable<IWorldTrackComponent> GetContents();
 
     }
 }

--- a/CorgEng.GenericInterfaces/World/IWorld.cs
+++ b/CorgEng.GenericInterfaces/World/IWorld.cs
@@ -18,7 +18,7 @@ namespace CorgEng.GenericInterfaces.World
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="mapLevel"></param>
-        void AddEntity(IEntity entity, double x, double y, int mapLevel);
+        void AddEntity(IWorldTrackComponent trackComponent, double x, double y, int mapLevel);
 
         /// <summary>
         /// Removes an entity from world tracking
@@ -28,7 +28,7 @@ namespace CorgEng.GenericInterfaces.World
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="mapLevel"></param>
-        void RemoveEntity(IEntity entity, double x, double y, int mapLevel);
+        void RemoveEntity(IWorldTrackComponent trackComponent, double x, double y, int mapLevel);
 
         /// <summary>
         /// Gets all of the contents at a given location.
@@ -44,21 +44,21 @@ namespace CorgEng.GenericInterfaces.World
         /// Adds an entity to the world tracking
         /// </summary>
         /// <param name="trackKey">The key of the map level to use. Allows for optimised searching of specific items that are searched a lot.</param>
-        /// <param name="entity"></param>
+        /// <param name="trackComponent"></param>
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="mapLevel"></param>
-        void AddEntity(string trackKey, IEntity entity, double x, double y, int mapLevel);
+        void AddEntity(string trackKey, IWorldTrackComponent trackComponent, double x, double y, int mapLevel);
 
         /// <summary>
         /// Removes an entity from world tracking
         /// </summary>
         /// <param name="trackKey">The key of the map level to use. Allows for optimised searching of specific items that are searched a lot.</param>
-        /// <param name="entity"></param>
+        /// <param name="trackComponent"></param>
         /// <param name="x"></param>
         /// <param name="y"></param>
         /// <param name="mapLevel"></param>
-        void RemoveEntity(string trackKey, IEntity entity, double x, double y, int mapLevel);
+        void RemoveEntity(string trackKey, IWorldTrackComponent trackComponent, double x, double y, int mapLevel);
 
         /// <summary>
         /// Gets all of the contents at a given location.

--- a/CorgEng.GenericInterfaces/World/IWorldTrackComponent.cs
+++ b/CorgEng.GenericInterfaces/World/IWorldTrackComponent.cs
@@ -1,0 +1,26 @@
+﻿using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.UtilityTypes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.GenericInterfaces.World
+{
+    public interface IWorldTrackComponent : IComponent
+    {
+
+        /// <summary>
+        /// The position of this component in the
+        /// array at the current position.
+        /// </summary>
+        int ContentsIndexPosition { get; set; }
+
+        /// <summary>
+        /// The tracked location of this component.
+        /// </summary>
+        IVector<int> ContentsLocation { get; set; }
+
+    }
+}

--- a/CorgEng.InputHandling/ClickHandler/WorldClickHandler.cs
+++ b/CorgEng.InputHandling/ClickHandler/WorldClickHandler.cs
@@ -36,7 +36,7 @@ namespace CorgEng.InputHandling.ClickHandler
         //Track the last clicked location for cyclical selection of entities
         private static int lastClickedX = 0;
         private static int lastClickedY = 0;
-        private static IEnumerator<IEntity> contentEnumerator;
+        private static IEnumerator<IWorldTrackComponent> contentEnumerator;
 
         public override EntitySystemFlags SystemFlags => EntitySystemFlags.CLIENT_SYSTEM;
 
@@ -131,8 +131,8 @@ namespace CorgEng.InputHandling.ClickHandler
                     return;
                 }
             }
-            //Select the element
-            contentEnumerator.Current.AddComponent(new SelectedComponent());
+            //Select the element (TODO: SelectableComponent)
+            contentEnumerator.Current.Parent.AddComponent(new SelectedComponent());
             Logger.WriteLine($"({releaseEvent.CursorX * 2 - 1}, {releaseEvent.CursorY * 2 - 1}), {clickedLocation} Selected Entity: {contentEnumerator.Current}");
         }
     }

--- a/CorgEng.Tests/World/WorldTests.cs
+++ b/CorgEng.Tests/World/WorldTests.cs
@@ -2,6 +2,7 @@
 using CorgEng.EntityComponentSystem.Entities;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.World;
+using CorgEng.World.Components;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -24,13 +25,13 @@ namespace CorgEng.Tests.World
         {
             Assert.IsNotNull(WorldAccess, "Dependency injection failed");
             //Create some entities
-            IEntity entityA = new Entity();
-            IEntity entityB = new Entity();
-            IEntity entityC = new Entity();
-            IEntity entityD = new Entity();
-            IEntity entityE = new Entity();
-            IEntity entityF = new Entity();
-            IEntity entityG = new Entity();
+            IWorldTrackComponent entityA = new TrackComponent("default");
+            IWorldTrackComponent entityB = new TrackComponent("default");
+            IWorldTrackComponent entityC = new TrackComponent("default");
+            IWorldTrackComponent entityD = new TrackComponent("default");
+            IWorldTrackComponent entityE = new TrackComponent("default");
+            IWorldTrackComponent entityF = new TrackComponent("default");
+            IWorldTrackComponent entityG = new TrackComponent("default");
             //Do some adding and removing
             WorldAccess.AddEntity(entityA, 1, 1, 0);
             WorldAccess.AddEntity(entityB, 1, 1, 0);
@@ -48,7 +49,7 @@ namespace CorgEng.Tests.World
             //(1, 1, 0)
             bool foundA = false;
             bool foundB = false;
-            foreach (IEntity entity in WorldAccess.GetContentsAt(1, 1, 0).GetContents())
+            foreach (IWorldTrackComponent entity in WorldAccess.GetContentsAt(1, 1, 0).GetContents())
             {
                 if (entity == entityA && !foundA)
                     foundA = true;
@@ -59,7 +60,7 @@ namespace CorgEng.Tests.World
             }
             //(-1, 0, 0)
             bool foundE = false;
-            foreach (IEntity entity in WorldAccess.GetContentsAt(-1, 0, 0).GetContents())
+            foreach (IWorldTrackComponent entity in WorldAccess.GetContentsAt(-1, 0, 0).GetContents())
             {
                 if (entity == entityE && !foundE)
                     foundE = true;
@@ -68,7 +69,7 @@ namespace CorgEng.Tests.World
             }
             //(0, 0, 6)
             bool foundD = false;
-            foreach (IEntity entity in WorldAccess.GetContentsAt(0, 0, 6).GetContents())
+            foreach (IWorldTrackComponent entity in WorldAccess.GetContentsAt(0, 0, 6).GetContents())
             {
                 if (entity == entityD && !foundD)
                     foundD = true;
@@ -77,7 +78,7 @@ namespace CorgEng.Tests.World
             }
             //('FG', 0, 0, 7)
             bool foundF = false;
-            foreach (IEntity entity in WorldAccess.GetContentsAt("FG", 0, 0, 7).GetContents())
+            foreach (IWorldTrackComponent entity in WorldAccess.GetContentsAt("FG", 0, 0, 7).GetContents())
             {
                 if (entity == entityF && !foundF)
                     foundF = true;
@@ -86,7 +87,7 @@ namespace CorgEng.Tests.World
             }
             //('FG', 0, 4, 6)
             bool foundG = false;
-            foreach (IEntity entity in WorldAccess.GetContentsAt("FG", 0, 4, 6).GetContents())
+            foreach (IWorldTrackComponent entity in WorldAccess.GetContentsAt("FG", 0, 4, 6).GetContents())
             {
                 if (entity == entityG && !foundG)
                     foundG = true;

--- a/CorgEng.World/EntitySystems/WorldSystem.cs
+++ b/CorgEng.World/EntitySystems/WorldSystem.cs
@@ -24,52 +24,9 @@ namespace CorgEng.World.EntitySystems
 
         public override void SystemSetup()
         {
-            RegisterLocalEvent<TransformComponent, ComponentAddedEvent>(OnEntityCreated);
-            RegisterLocalEvent<TransformComponent, MoveEvent>(OnEntityMoved);
-            RegisterLocalEvent<TransformComponent, ComponentRemovedEvent>(OnComponentRemoved);
             RegisterLocalEvent<TrackComponent, ComponentAddedEvent>(OnEntityCreated);
             RegisterLocalEvent<TrackComponent, MoveEvent>(OnEntityMoved);
             RegisterLocalEvent<TrackComponent, ComponentRemovedEvent>(OnComponentRemoved);
-        }
-
-        /// <summary>
-        /// When the transform component is added to an entity, it needs
-        /// to begin tracking in the world system.
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="transformComponent"></param>
-        /// <param name="componentAddedEvent"></param>
-        private void OnEntityCreated(IEntity entity, TransformComponent transformComponent, ComponentAddedEvent componentAddedEvent)
-        {
-            if (componentAddedEvent.Component != transformComponent)
-                return;
-            //Add the entity to the world
-            WorldAccess.AddEntity(entity, transformComponent.Position.X, transformComponent.Position.Y, 0);
-        }
-
-        /// <summary>
-        /// When the entity moves it needs to be updated in the world system.
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="transformComponent"></param>
-        /// <param name="moveEvent"></param>
-        private void OnEntityMoved(IEntity entity, TransformComponent transformComponent, MoveEvent moveEvent)
-        {
-            WorldAccess.RemoveEntity(entity, entity.ContentsLocation.X, entity.ContentsLocation.Y, 0);
-            WorldAccess.AddEntity(entity, moveEvent.NewPosition.X, moveEvent.NewPosition.Y, 0);
-        }
-
-        /// <summary>
-        /// Stop tracking a component when the transform is removed
-        /// </summary>
-        /// <param name="entity"></param>
-        /// <param name="transformComponent"></param>
-        /// <param name="componentRemovedEvent"></param>
-        private void OnComponentRemoved(IEntity entity, TransformComponent transformComponent, ComponentRemovedEvent componentRemovedEvent)
-        {
-            if (componentRemovedEvent.Component != transformComponent)
-                return;
-            WorldAccess.RemoveEntity(entity, transformComponent.Position.X, transformComponent.Position.Y, 0);
         }
 
         /// <summary>
@@ -84,7 +41,7 @@ namespace CorgEng.World.EntitySystems
             if (componentAddedEvent.Component != trackComponent)
                 return;
             //Add the entity to the world
-            WorldAccess.AddEntity(trackComponent.Key, entity, trackComponent.Transform.Position.X, trackComponent.Transform.Position.Y, 0);
+            WorldAccess.AddEntity(trackComponent.Key, trackComponent, trackComponent.Transform.Position.X, trackComponent.Transform.Position.Y, 0);
         }
 
         /// <summary>
@@ -95,8 +52,8 @@ namespace CorgEng.World.EntitySystems
         /// <param name="moveEvent"></param>
         private void OnEntityMoved(IEntity entity, TrackComponent trackComponent, MoveEvent moveEvent)
         {
-            WorldAccess.RemoveEntity(trackComponent.Key, entity, moveEvent.OldPosition.X, moveEvent.OldPosition.Y, 0);
-            WorldAccess.AddEntity(trackComponent.Key, entity, moveEvent.NewPosition.X, moveEvent.NewPosition.Y, 0);
+            WorldAccess.RemoveEntity(trackComponent.Key, trackComponent, moveEvent.OldPosition.X, moveEvent.OldPosition.Y, 0);
+            WorldAccess.AddEntity(trackComponent.Key, trackComponent, moveEvent.NewPosition.X, moveEvent.NewPosition.Y, 0);
         }
 
         /// <summary>
@@ -109,7 +66,7 @@ namespace CorgEng.World.EntitySystems
         {
             if (componentRemovedEvent.Component != trackComponent)
                 return;
-            WorldAccess.RemoveEntity(trackComponent.Key, entity, trackComponent.Transform.Position.X, trackComponent.Transform.Position.Y, 0);
+            WorldAccess.RemoveEntity(trackComponent.Key, trackComponent, trackComponent.Transform.Position.X, trackComponent.Transform.Position.Y, 0);
         }
 
     }

--- a/CorgEng.World/WorldTracking/ContentsEnumerable.cs
+++ b/CorgEng.World/WorldTracking/ContentsEnumerable.cs
@@ -1,4 +1,5 @@
 ﻿using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.World;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -8,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace CorgEng.World.WorldTracking
 {
-    internal class ContentsEnumerable : IEnumerable<IEntity>
+    internal class ContentsEnumerable : IEnumerable<IWorldTrackComponent>
     {
 
         private ContentsHolder holder;
@@ -18,7 +19,7 @@ namespace CorgEng.World.WorldTracking
             holder = parent;
         }
 
-        public IEnumerator<IEntity> GetEnumerator()
+        public IEnumerator<IWorldTrackComponent> GetEnumerator()
         {
             return new ContentsEnumerator(holder);
         }

--- a/CorgEng.World/WorldTracking/ContentsEnumerator.cs
+++ b/CorgEng.World/WorldTracking/ContentsEnumerator.cs
@@ -1,4 +1,5 @@
 ﻿using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.World;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -8,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace CorgEng.World.WorldTracking
 {
-    internal class ContentsEnumerator : IEnumerator<IEntity>
+    internal class ContentsEnumerator : IEnumerator<IWorldTrackComponent>
     {
 
         /// <summary>
@@ -21,7 +22,7 @@ namespace CorgEng.World.WorldTracking
             reference = contentsHolder;
         }
 
-        public IEntity Current => head < reference.contentsArray.Length ? reference.contentsArray[head] : null;
+        public IWorldTrackComponent Current => head < reference.contentsArray.Length ? reference.contentsArray[head] : null;
 
         object IEnumerator.Current => reference.contentsArray[head];
 

--- a/CorgEng.World/WorldTracking/ContentsHolder.cs
+++ b/CorgEng.World/WorldTracking/ContentsHolder.cs
@@ -35,7 +35,7 @@ namespace CorgEng.World.WorldTracking
         /// </summary>
         private int fragmentationFactor = 0;
 
-        internal IEntity[] contentsArray = new IEntity[DEFAULT_CONTENT_ARRAY_SIZE];
+        internal IWorldTrackComponent[] contentsArray = new IWorldTrackComponent[DEFAULT_CONTENT_ARRAY_SIZE];
 
         /// <summary>
         /// Maximum value used in the array
@@ -49,18 +49,18 @@ namespace CorgEng.World.WorldTracking
             position = new Vector<int>(x, y);
         }
 
-        public IEnumerable<IEntity> GetContents()
+        public IEnumerable<IWorldTrackComponent> GetContents()
         {
             return new ContentsEnumerable(this);
         }
 
-        public void Insert(IEntity entity)
+        public void Insert(IWorldTrackComponent entity)
         {
             //Array needs growing
             while (nextInsertionPointer == contentsArray.Length)
             {
-                IEntity[] arrayRef = contentsArray;
-                contentsArray = new Entity[arrayRef.Length * ARRAY_GROWTH_FACTORY];
+                IWorldTrackComponent[] arrayRef = contentsArray;
+                contentsArray = new IWorldTrackComponent[arrayRef.Length * ARRAY_GROWTH_FACTORY];
                 arrayRef.CopyTo(contentsArray, 0);
             }
             //Array needs defragmenting
@@ -81,21 +81,21 @@ namespace CorgEng.World.WorldTracking
                 fragmentationFactor = 0;
             }
             //Insert the entity
-            entity.ContentsIndex = nextInsertionPointer;
+            entity.ContentsIndexPosition = nextInsertionPointer;
             entity.ContentsLocation = position;
             contentsArray[nextInsertionPointer] = entity;
             //Insert the next entity in the next position
             nextInsertionPointer++;
         }
 
-        public void Remove(IEntity entity)
+        public void Remove(IWorldTrackComponent entity)
         {
             //Validation check
-            if (entity.ContentsIndex >= contentsArray.Length || entity.ContentsIndex < 0 || contentsArray[entity.ContentsIndex] != entity)
-                throw new Exception($"Invalid entity in WorldTile array, entity claims to be at position {entity.ContentsIndex}");
+            if (entity.ContentsIndexPosition >= contentsArray.Length || entity.ContentsIndexPosition < 0 || contentsArray[entity.ContentsIndexPosition] != entity)
+                throw new Exception($"Invalid entity in WorldTile array, entity claims to be at position {entity.ContentsIndexPosition}");
             //Remove the entity
-            contentsArray[entity.ContentsIndex] = null;
-            entity.ContentsIndex = -1;
+            contentsArray[entity.ContentsIndexPosition] = null;
+            entity.ContentsIndexPosition = -1;
             //Increase the fragmentation factor
             fragmentationFactor++;
         }

--- a/CorgEng.World/WorldTracking/World.cs
+++ b/CorgEng.World/WorldTracking/World.cs
@@ -35,9 +35,9 @@ namespace CorgEng.World.WorldTracking
             }
         }
 
-        public void AddEntity(string trackKey, IEntity entity, double x, double y, int mapLevel)
+        public void AddEntity(string trackKey, IWorldTrackComponent trackComponent, double x, double y, int mapLevel)
         {
-            if (entity.ContentsIndex != -1)
+            if (trackComponent.ContentsIndexPosition != -1)
                 throw new Exception($"Attempting to insert an entity while it is already in another location");
             if (!WorldTiles.ContainsKey(trackKey))
             {
@@ -60,12 +60,12 @@ namespace CorgEng.World.WorldTracking
                 worldTile = new ContentsHolder(xInteger, yInteger);
                 targetLevel.Add(xInteger, yInteger, worldTile);
             }
-            worldTile.Insert(entity);
+            worldTile.Insert(trackComponent);
         }
 
-        public void AddEntity(IEntity entity, double x, double y, int mapLevel)
+        public void AddEntity(IWorldTrackComponent trackComponent, double x, double y, int mapLevel)
         {
-            AddEntity("_world", entity, x, y, mapLevel);
+            AddEntity("_world", trackComponent, x, y, mapLevel);
         }
 
         public IContentsHolder GetContentsAt(string trackKey, double x, double y, int mapLevel)
@@ -80,9 +80,9 @@ namespace CorgEng.World.WorldTracking
             return GetContentsAt("_world", x, y, mapLevel);
         }
 
-        public void RemoveEntity(string trackKey, IEntity entity, double x, double y, int mapLevel)
+        public void RemoveEntity(string trackKey, IWorldTrackComponent trackComponent, double x, double y, int mapLevel)
         {
-            if (entity.ContentsIndex == -1)
+            if (trackComponent.ContentsIndexPosition == -1)
                 throw new Exception($"Attempting to remove an entity from an invalid location ({x}, {y})");
             IPositionBasedBinaryList<ContentsHolder> targetLevel = WorldTiles[trackKey].ElementWithKey(mapLevel);
             //Target doesn't exist
@@ -96,12 +96,12 @@ namespace CorgEng.World.WorldTracking
             ContentsHolder worldTile = targetLevel.Get(xInteger, yInteger);
             if (worldTile == null)
                 return;
-            worldTile.Remove(entity);
+            worldTile.Remove(trackComponent);
         }
 
-        public void RemoveEntity(IEntity entity, double x, double y, int mapLevel)
+        public void RemoveEntity(IWorldTrackComponent trackComponent, double x, double y, int mapLevel)
         {
-            RemoveEntity("_world", entity, x, y, mapLevel);
+            RemoveEntity("_world", trackComponent, x, y, mapLevel);
         }
     }
 }


### PR DESCRIPTION
closes #66 
You can now have the same entity in different world layers.
Cleans up world tracking code to not be integrated directly with IEntity.