### PR TITLE
Entities are deletable by default

### DIFF
--- a/CorgEng.EntityComponentSystem/Entities/Entity.cs
+++ b/CorgEng.EntityComponentSystem/Entities/Entity.cs
@@ -2,6 +2,7 @@
 using CorgEng.EntityComponentSystem.Components;
 using CorgEng.EntityComponentSystem.Events;
 using CorgEng.EntityComponentSystem.Events.Events;
+using CorgEng.EntityComponentSystem.Implementations.Deletion;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Logging;
 using CorgEng.GenericInterfaces.UtilityTypes;
@@ -51,12 +52,16 @@ namespace CorgEng.EntityComponentSystem.Entities
         {
             Identifier = EntityManager.GetNewEntityId();
             EntityManager.RegisterEntity(this);
+            //Entities are deletable by default
+            AddComponent(new DeleteableComponent());
         }
 
         public Entity(uint identifier)
         {
             Identifier = identifier;
             EntityManager.RegisterEntity(this);
+            //Entities are deletable by default
+            AddComponent(new DeleteableComponent());
         }
 
         ~Entity()

--- a/CorgEng.Networking/Networking/Server/NetworkingServer.cs
+++ b/CorgEng.Networking/Networking/Server/NetworkingServer.cs
@@ -111,7 +111,6 @@ namespace CorgEng.Networking.Networking.Server
             IEntity sampleEntity = new Entity();
             sampleEntity.AddComponent(new NetworkTransformComponent());
             sampleEntity.AddComponent(new ClientComponent());
-            sampleEntity.AddComponent(new DeleteableComponent());
             //Get the prototype
             DefaultEntityPrototype = PrototypeManager.GetPrototype(sampleEntity, false);
             //Delete the entity

--- a/CorgEng.Networking/Prototypes/Prototype.cs
+++ b/CorgEng.Networking/Prototypes/Prototype.cs
@@ -1,5 +1,6 @@
 ﻿using CorgEng.Core.Dependencies;
 using CorgEng.EntityComponentSystem.Entities;
+using CorgEng.EntityComponentSystem.Implementations.Deletion;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Logging;
 using CorgEng.GenericInterfaces.Networking.PrototypeManager;
@@ -131,6 +132,9 @@ namespace CorgEng.Networking.Prototypes
             //Go through each component and serialize it
             foreach (Type componentType in prototypeComponents.Keys)
             {
+                //Ignore deletable compoent since its common
+                if (componentType == typeof(DeleteableComponent))
+                    continue;
                 //First serialize a component identifier
                 ushort typeIdentifier = componentType.GetNetworkedIdentifier();
                 size += sizeof(ushort);

--- a/CorgEng.Tests/NetworkingTests/EntityCommunicatorTests.cs
+++ b/CorgEng.Tests/NetworkingTests/EntityCommunicatorTests.cs
@@ -1,5 +1,6 @@
 ﻿using CorgEng.Core.Dependencies;
 using CorgEng.EntityComponentSystem.Entities;
+using CorgEng.EntityComponentSystem.Implementations.Deletion;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Logging;
 using CorgEng.GenericInterfaces.Networking.Networking;
@@ -64,6 +65,8 @@ namespace CorgEng.Tests.NetworkingTests
 
             foreach (IComponent component in deserialisedEntity.Components)
             {
+                if (component is DeleteableComponent)
+                    continue;
                 if (component is TestComponent addedTestComponent)
                 {
                     //Add a test component

--- a/CorgEng.Tests/NetworkingTests/PrototypeTests.cs
+++ b/CorgEng.Tests/NetworkingTests/PrototypeTests.cs
@@ -94,7 +94,7 @@ namespace CorgEng.Tests.NetworkingTests
             IEntity createdEntity = deserialisedPrototype.CreateEntityFromPrototype();     //We don't care about the identifier for this test
             //Verify the entity is correct
             Assert.AreEqual(entity.Components.Count, createdEntity.Components.Count);
-            TestComponent deserializedComponent = (TestComponent)createdEntity.Components[0];
+            TestComponent deserializedComponent = (TestComponent)createdEntity.Components[1];
             Assert.AreEqual(59, deserializedComponent.Integer);
             Assert.AreEqual("Hello World!", deserializedComponent.Text);
             Assert.AreEqual(3.14159265, deserializedComponent.Double);


### PR DESCRIPTION
Entities are now deletable by default.
All entities should respond to the DeleteEntityEvent, it doesn't make sense that you have to register a component for this event to actually have any effect.