### PR TITLE
Content loading ID

### DIFF
--- a/CorgEng.ContentLoading/DefinitionNodes/ComponentNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ComponentNode.cs
@@ -17,10 +17,6 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
         public ComponentNode(DefinitionNode parent) : base(parent)
         {
             Parent = parent as EntityNode;
-            if (Parent == null)
-            {
-                throw new ContentLoadException("Component nodes must be children of an entity node.");
-            }
         }
 
         public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)

--- a/CorgEng.ContentLoading/DefinitionNodes/DefinitionNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/DefinitionNode.cs
@@ -14,6 +14,8 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
 
         protected string? Key { get; private set; }
 
+        public string? ID { get; set; }
+
         public DefinitionNode(DefinitionNode parent)
         {
             parent?.Children.Add(this);
@@ -26,6 +28,8 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
         public virtual void ParseSelf(XmlNode node)
         {
             Key = node.Attributes["key"]?.Value;
+            // The ID of the node, makes it accessible by other nodes
+            ID = node.Attributes["id"]?.Value;
         }
 
         /// <summary>

--- a/CorgEng.ContentLoading/DefinitionNodes/EntityNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/EntityNode.cs
@@ -16,8 +16,6 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
         [UsingDependency]
         public static IEntityFactory EntityFactory;
 
-        public string Name { get; set; }
-
         public bool Abstract { get; set; } = false;
 
         /// <summary>
@@ -37,9 +35,13 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
         {
             //Perform base parsing actions
             base.ParseSelf(node);
-            Name = node.Attributes["name"].Value;
+            // Allow ID to be got from the 'name' attribute from backwards compatability.
+            ID = node.Attributes["id"]?.Value ?? node.Attributes["name"]?.Value;
             Abstract = node.Attributes["abstract"]?.Value.ToLower() == "true";
-            EntityCreator.EntityNodesByName.Add(Name, this);
+            if (!string.IsNullOrEmpty(ID))
+            {
+                EntityCreator.EntityNodesByName.Add(ID, this);
+            }
         }
 
         /// <summary>

--- a/CorgEng.ContentLoading/DefinitionNodes/InstanceNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/InstanceNode.cs
@@ -27,7 +27,14 @@ namespace CorgEng.ContentLoading.DefinitionNodes
 
         public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
         {
-            return instanceRefs[referenceName];
+            if (instanceRefs.ContainsKey(referenceName))
+            {
+                return instanceRefs[referenceName];
+            }
+            else
+            {
+                return EntityLoader.GetDefinition(referenceName);
+            }
         }
 
     }


### PR DESCRIPTION
Implements the ID tag into content loading, with the ability to insert snippets from other content load things in.
This allows for stuff like blueprint to be represented in the content loading system.

![image](https://user-images.githubusercontent.com/26465327/190499673-a1ae6d98-51cc-48ab-b685-fd7e50be6231.png)
Local keyed elements will work inside of Instances that are inserted, as shown above (pawn has the key pawn, which is accessible inside of the component with ID test).

![image](https://user-images.githubusercontent.com/26465327/190499648-06faccac-d897-460c-8512-131d8ac6ac11.png)

Intended usecase is for blueprints, which aren't entities but still need to be able to be stored inside the content loading system files.
We will have a list with an ID, which holds instances to all of these blueprint objects and then implement a method later which allows us to fetch objects from the content loading system, rather than only entities.