### PR TITLE
Adds in content loading dictionaries and a basic test structure

### DIFF
--- a/CorgEng.ContentLoading/DefinitionNodes/ArrayNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ArrayNode.cs
@@ -12,7 +12,7 @@ namespace CorgEng.ContentLoading.DefinitionNodes
     {
 
         //Get the type of the array
-        Type arrayType;
+        internal Type arrayType;
 
         public ArrayNode(DefinitionNode parent) : base(parent)
         {

--- a/CorgEng.ContentLoading/DefinitionNodes/DictionaryNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/DictionaryNode.cs
@@ -1,0 +1,65 @@
+﻿using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml;
+
+namespace CorgEng.ContentLoading.DefinitionNodes
+{
+    internal class DictionaryNode : DefinitionNode
+    {
+
+        //Get the type of the array
+        internal Type keyType;
+        internal Type valueType;
+
+        private Type dictionaryType;
+
+        internal Type keyValuePairType;
+
+        private MethodInfo addMethod;
+
+        public DictionaryNode(DefinitionNode parent) : base(parent)
+        {
+        }
+
+        public override void ParseSelf(XmlNode node)
+        {
+            //Perform base parsing actions
+            base.ParseSelf(node);
+            //Get the array type
+            keyType = EntityLoader.TypePaths[node.Attributes["keyType"].Value];
+            valueType = EntityLoader.TypePaths[node.Attributes["valueType"].Value];
+            dictionaryType = typeof(Dictionary<object, object>).GetGenericTypeDefinition().MakeGenericType(keyType, valueType);
+            keyValuePairType = typeof(KeyValuePair<object, object>).GetGenericTypeDefinition().MakeGenericType(keyType, valueType);
+            Type iCollectionType = typeof(ICollection<object>).GetGenericTypeDefinition().MakeGenericType(keyValuePairType);
+            addMethod = iCollectionType.GetMethod(
+                "Add",
+                BindingFlags.Public | BindingFlags.Instance);
+        }
+
+        public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
+        {
+            //Create the array object
+            object dictionary = Activator.CreateInstance(dictionaryType);
+            //Populate the dictionary
+            foreach (DefinitionNode child in Children)
+            {
+                addMethod.Invoke(dictionary, new object[] {
+                    child.CreateInstance(dictionary, instanceRefs)
+                });
+            }
+            //Add a reference to the created array
+            if (Key != null)
+            {
+                instanceRefs.Add(Key, dictionary);
+            }
+            //return the array
+            return dictionary;
+        }
+
+    }
+}

--- a/CorgEng.ContentLoading/DefinitionNodes/ElementNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ElementNode.cs
@@ -1,7 +1,9 @@
 ﻿using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using System.Xml;
@@ -12,18 +14,60 @@ namespace CorgEng.ContentLoading.DefinitionNodes
     {
 
         /// <summary>
+        /// The property that we target
+        /// </summary>
+        public Type ParentType { get; private set; }
+
+        /// <summary>
         /// The value to apply, unless we contain an object node as a child
         /// </summary>
         public object PropertyValue { get; protected set; }
 
+        /// <summary>
+        /// Type of the dictionary key, if our parent is a dictionary
+        /// </summary>
+        private Type dictionaryParentKeyType;
+
+        /// <summary>
+        /// Type of the dictionary key, if our parent is a dictionary
+        /// </summary>
+        private Type dictionaryParentValueType;
+
         public ElementNode(DefinitionNode parent) : base(parent)
         {
+            //Determine return type
+            if (parent is ArrayNode array)
+            {
+                ParentType = array.arrayType;
+            }
+            else if (parent is DictionaryNode dictionary)
+            {
+                ParentType = dictionary.keyValuePairType;
+                dictionaryParentKeyType = dictionary.keyType;
+                dictionaryParentValueType = dictionary.valueType;
+            }
+            else
+            {
+                throw new ContentLoadException("Invalid element node, must be a child of an Array or a Dictionary.");
+            }
         }
 
         public override void ParseSelf(XmlNode node)
         {
             //Perform base parsing actions
             base.ParseSelf(node);
+            //Determine our property value
+            ParseValue(node);
+        }
+
+        protected void ParseValue(XmlNode node)
+        {
+            //If we are a value type, attempt to directly convert
+            if ((!ParentType.IsGenericType && ParentType.IsValueType) || ParentType == typeof(string))
+            {
+                //Since its a value type, we should be able to just convert it from a string
+                PropertyValue = TypeDescriptor.GetConverter(ParentType).ConvertFrom(node.InnerText.Trim());
+            }
         }
 
         public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
@@ -36,13 +80,41 @@ namespace CorgEng.ContentLoading.DefinitionNodes
             return propertyValue;
         }
 
+        private static MethodInfo cachedMethod = null;
+
         private object GetValue(object parent, Dictionary<string, object> instanceRefs)
         {
+            //Has 2 children, key value pair
+            if (Children.Count == 2)
+            {
+                //Order matters for optimisation sake
+                //Select the key
+                KeyNode childKey = Children[0] as KeyNode;
+                //Select the value
+                ValueNode childValue = Children[1] as ValueNode;
+                //Return a key value pair with the specified types
+                if (cachedMethod == null)
+                {
+                    cachedMethod = typeof(KeyValuePair).GetMethod("Create", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.Public);
+                }
+                //Make the generic method and call it
+                return cachedMethod.MakeGenericMethod(dictionaryParentKeyType, dictionaryParentValueType).Invoke(null, new object[] {
+                    childKey.CreateInstance(parent, instanceRefs),
+                    childValue.CreateInstance(parent, instanceRefs)
+                });
+
+            }
+            if (Children.Count != 1)
+            {
+                throw new ContentLoadException("Element node contains invalid children count, it should either contain a single value, or a <Key> and <Value> node.");
+            }
+            //1 Child, return value
             if (PropertyValue != null)
             {
                 return PropertyValue;
             }
-            else if (Children[0] is ObjectNode childNode)
+            // Either object or value node
+            else if (Children[0] is ObjectNode childNode && !(Children[0] is KeyNode))
             {
                 object createdObject = childNode.CreateInstance(null, instanceRefs);
                 return createdObject;
@@ -54,7 +126,7 @@ namespace CorgEng.ContentLoading.DefinitionNodes
             }
             else
             {
-                throw new Exception("Failed to set array node, invalid value.");
+                throw new ContentLoadException("Failed to set array node, invalid value.");
             }
         }
 

--- a/CorgEng.ContentLoading/DefinitionNodes/KeyNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/KeyNode.cs
@@ -1,0 +1,18 @@
+﻿using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.ContentLoading.DefinitionNodes
+{
+    internal class KeyNode : ObjectNode
+    {
+
+        public KeyNode(DefinitionNode parent) : base(parent)
+        {
+        }
+
+    }
+}

--- a/CorgEng.ContentLoading/DefinitionNodes/ObjectNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ObjectNode.cs
@@ -1,6 +1,7 @@
 ﻿using CorgEng.ContentLoading;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
@@ -13,7 +14,20 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
     internal class ObjectNode : DefinitionNode
     {
 
+        /// <summary>
+        /// The type that we want to treat the object as
+        /// </summary>
+        public Type ReturnType { get; set; }
+
+        /// <summary>
+        /// The type that we want to create.
+        /// </summary>
         public Type ObjectType { get; set; }
+
+        /// <summary>
+        /// The value to apply, unless we contain an object node as a child
+        /// </summary>
+        public object PropertyValue { get; protected set; }
 
         public ObjectNode(DefinitionNode parent) : base(parent)
         {
@@ -23,18 +37,46 @@ namespace CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes
         {
             //Perform base parsing actions
             base.ParseSelf(node);
-            string typeName = node.Attributes["type"].Value;
+            //The type that we want to create
+            string typeName = node.Attributes["createdType"]?.Value ?? node.Attributes["type"]?.Value;
             if (!EntityLoader.TypePaths.ContainsKey(typeName))
             {
                 throw new ContentLoadException($"Failed to load object node, the type {typeName} does not exist.");
             }
             ObjectType = EntityLoader.TypePaths[typeName];
+            //The type that we want to return
+            typeName = node.Attributes["returnType"]?.Value;
+            if (typeName == null)
+            {
+                //Return the type that we created.
+                ReturnType = ObjectType;
+            }
+            else
+            {
+                if (!EntityLoader.TypePaths.ContainsKey(typeName))
+                {
+                    throw new ContentLoadException($"Failed to load object node, the type {typeName} does not exist.");
+                }
+                ReturnType = EntityLoader.TypePaths[typeName];
+            }
+            //Determine our property value
+            ParseValue(node);
+        }
+
+        protected void ParseValue(XmlNode node)
+        {
+            //If we are a value type, attempt to directly convert
+            if ((!ObjectType.IsGenericType && ObjectType.IsValueType) || ObjectType == typeof(string))
+            {
+                //Since its a value type, we should be able to just convert it from a string
+                PropertyValue = TypeDescriptor.GetConverter(ObjectType).ConvertFrom(node.InnerText.Trim());
+            }
         }
 
         public override object CreateInstance(object parent, Dictionary<string, object> instanceRefs)
         {
             //Create ourself
-            object createdObject = Activator.CreateInstance(ObjectType);
+            object createdObject = PropertyValue ?? Activator.CreateInstance(ObjectType);
             //Store it
             if (Key != null)
             {

--- a/CorgEng.ContentLoading/DefinitionNodes/ValueNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/ValueNode.cs
@@ -1,0 +1,18 @@
+﻿using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.ContentLoading.DefinitionNodes
+{
+    internal class ValueNode : ObjectNode
+    {
+
+        public ValueNode(DefinitionNode parent) : base(parent)
+        {
+        }
+
+    }
+}

--- a/CorgEng.ContentLoading/EntityCreator.cs
+++ b/CorgEng.ContentLoading/EntityCreator.cs
@@ -1,7 +1,9 @@
-﻿using CorgEng.DependencyInjection.Dependencies;
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.DependencyInjection.Dependencies;
 using CorgEng.GenericInterfaces.ContentLoading;
 using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,6 +15,9 @@ namespace CorgEng.ContentLoading
     [Dependency]
     internal class EntityCreator : IEntityCreator
     {
+
+        [UsingDependency]
+        private static ILogger Logger;
 
         /// <summary>
         /// The entity nodes by the name
@@ -29,12 +34,20 @@ namespace CorgEng.ContentLoading
         /// <exception cref="Exception"></exception>
         public IEntity CreateEntity(string entityName)
         {
-            if (EntityNodesByName.ContainsKey(entityName))
+            try
             {
-                return EntityNodesByName[entityName].CreateEntity();
+                if (EntityNodesByName.ContainsKey(entityName))
+                {
+                    return EntityNodesByName[entityName].CreateEntity();
+                }
+                //Entity not found :(
+                throw new Exception($"The entity with name {entityName} could not be spawned as it doesn't exist.");
             }
-            //Entity not found :(
-            throw new Exception($"The entity with name {entityName} could not be spawned as it doesn't exist.");
+            catch (Exception e)
+            {
+                Logger.WriteLine($"An expection occured while creating entity with ID '{entityName}': {e}", LogType.ERROR);
+                throw;
+            }
         }
 
         /// <summary>
@@ -45,12 +58,20 @@ namespace CorgEng.ContentLoading
         /// <exception cref="Exception"></exception>
         public object CreateObject(string objectIdentifier)
         {
-            if (EntityLoader.LoadedDefinitions.ContainsKey(objectIdentifier))
+            try
             {
-                return EntityLoader.LoadedDefinitions[objectIdentifier].CreateInstance(null, new Dictionary<string, object>());
+                if (EntityLoader.LoadedDefinitions.ContainsKey(objectIdentifier))
+                {
+                    return EntityLoader.LoadedDefinitions[objectIdentifier].CreateInstance(null, new Dictionary<string, object>());
+                }
+                //Entity not found :(
+                throw new Exception($"The object with name {objectIdentifier} could not be spawned as it doesn't exist.");
             }
-            //Entity not found :(
-            throw new Exception($"The object with name {objectIdentifier} could not be spawned as it doesn't exist.");
+            catch (Exception e)
+            {
+                Logger.WriteLine($"An expection occured while creating object with ID '{objectIdentifier}': {e}", LogType.ERROR);
+                throw;
+            }
         }
 
     }

--- a/CorgEng.ContentLoading/EntityLoader.cs
+++ b/CorgEng.ContentLoading/EntityLoader.cs
@@ -145,6 +145,7 @@ namespace CorgEng.ContentLoading
 
         private static void RecursivelyParse(XmlNode node, DefinitionNode parentNode = null)
         {
+            //Ignore text and comments
             if (node is XmlText || node is XmlComment)
                 return;
             //Create the node

--- a/CorgEng.ContentLoading/EntityLoader.cs
+++ b/CorgEng.ContentLoading/EntityLoader.cs
@@ -30,6 +30,14 @@ namespace CorgEng.ContentLoading
         /// </summary>
         internal static Dictionary<string, DefinitionNode> LoadedDefinitions = new Dictionary<string, DefinitionNode>();
 
+        public static IEnumerable<string> LoadedDefinitionNames
+        {
+            get => LoadedDefinitions.Keys;
+        }
+
+        /// <summary>
+        /// The load queue
+        /// </summary>
         private static Dictionary<string, XmlNode> XmlLoadQueue = new Dictionary<string, XmlNode>();
 
         [ModuleLoad]
@@ -95,8 +103,16 @@ namespace CorgEng.ContentLoading
                 XmlNode node = XmlLoadQueue[nodeName];
                 //Remove the node from the processing queue
                 XmlLoadQueue.Remove(nodeName);
-                //Load the node
-                RecursivelyParse(node);
+                try
+                {
+                    //Load the node
+                    RecursivelyParse(node);
+                }
+                catch (Exception e)
+                {
+                    //Throw a more detailed exception
+                    throw new ContentLoadException($"An exception occured while loading {nodeName} in {node.BaseURI}.", e);
+                }
             }
             //No longer required
             TypePaths = null;
@@ -162,6 +178,15 @@ namespace CorgEng.ContentLoading
                     break;
                 case "element":
                     createdNode = new ElementNode(parentNode);
+                    break;
+                case "key":
+                    createdNode = new KeyNode(parentNode);
+                    break;
+                case "value":
+                    createdNode = new ValueNode(parentNode);
+                    break;
+                case "dictionary":
+                    createdNode = new DictionaryNode(parentNode);
                     break;
                 default:
                     Logger?.WriteLine($"Unknown node in entitiy definition file: {node.Name}.", LogType.ERROR);

--- a/CorgEng.ContentLoading/EntityLoader.cs
+++ b/CorgEng.ContentLoading/EntityLoader.cs
@@ -145,6 +145,8 @@ namespace CorgEng.ContentLoading
 
         private static void RecursivelyParse(XmlNode node, DefinitionNode parentNode = null)
         {
+            if (node is XmlText || node is XmlComment)
+                return;
             //Create the node
             DefinitionNode createdNode;
             switch (node.Name.ToLower())

--- a/CorgEng.ContentLoading/README.md
+++ b/CorgEng.ContentLoading/README.md
@@ -68,14 +68,20 @@ Updates the property of the parent type.
 
 Creates a new object from a specified type. Can be used to create entities if the name attribute is used instead of the type.
 
+An object node can also contain direct values, such as intengers.
+
 #### Attributes:
 
  - name: If set, will locate and spawn the entity with this name.
- - type: If set, will create an object of the specified type.
+ - createdType (Required): If set, will create an object of the specified type.
+ - returnType (Optional):
 
 #### Content:
 
  - Can contain 'Property' nodes.
+ - Can contain direct values
+
+---
 
 ### Instance
 
@@ -124,6 +130,57 @@ An array of complex types:
 
 Defines an element of a collection type.
 Can either be a value type, or a complex type.
+
+---
+
+### Dictionary
+
+Creates a dictionary, which associates keys and values.
+Note that the type of the dictionary can differ to the types created by the 
+Key and Value pairs, as long as the type created by the key/value nodes
+are a child of the corresponding dictionary type.
+
+A dictionary with 'Object' keys can have Int32s inserted as keys.
+
+#### Attributes
+
+ - keyType (Required): The type of the dictionary key.
+ - valueType (Required): The type of the dictionary value.
+
+#### Content
+
+ - Must contain element nodes, which contain key and value nodes.
+
+#### Example
+
+```xml
+<Dictionary id="test_basic_dictionary" keyType="Int32" valueType="Int32">
+    <Element>
+        <Key createdType="Int32">1</Key>
+        <Value createdType="Int32">4</Value>
+    </Element>
+    <Element>
+        <Key createdType="Int32">2</Key>
+        <Value createdType="Int32">5</Value>
+    </Element>
+</Dictionary>
+```
+
+---
+
+### Key
+
+Defines the key of a KeyValuePair represented by an Element.
+
+See object node for more details.
+
+---
+
+### Value
+
+Defines the value of a KeyValuePair represented by an Element.
+
+See object node for more details.
 
 ---
 

--- a/CorgEng.Core/CorgEngMain.cs
+++ b/CorgEng.Core/CorgEngMain.cs
@@ -231,6 +231,9 @@ namespace CorgEng.Core
                     {
                         case "DependencyModules":
                             List<Assembly> loadedAssemblies = new List<Assembly>();
+                            //Add the system assembly
+                            loadedAssemblies.Add(typeof(string).Assembly);
+                            //Add the entry assembly
                             if (Assembly.GetEntryAssembly() != null)
                                 loadedAssemblies.Add(Assembly.GetEntryAssembly());
                             //Unit test support.

--- a/CorgEng.Tests/ContentLoadingTests/ContentLoadingTests.cs
+++ b/CorgEng.Tests/ContentLoadingTests/ContentLoadingTests.cs
@@ -1,0 +1,40 @@
+﻿using CorgEng.ContentLoading;
+using CorgEng.Core.Dependencies;
+using CorgEng.GenericInterfaces.ContentLoading;
+using CorgEng.GenericInterfaces.Logging;
+using CorgEng.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.Tests.ContentLoadingTests
+{
+    [TestClass]
+    public class ContentLoadingTests
+    {
+
+        [UsingDependency]
+        private static IEntityCreator EntityCreator;
+
+        [UsingDependency]
+        private static ILogger Logger;
+
+        [TestMethod]
+        public void TestContentLoading()
+        {
+            EntityLoader.LoadEntities();
+            Assert.AreEqual(0, ConsoleLogger.ExceptionCount, "An exception occured during entity loading. See logs for details.");
+            //Spawn everything to test spawning
+            foreach (string name in EntityLoader.LoadedDefinitionNames)
+            {
+                EntityCreator.CreateObject(name);
+                Logger.WriteLine($"Successfully created an instant of {name}.", LogType.LOG);
+                Assert.AreEqual(0, ConsoleLogger.ExceptionCount, $"Failed to spawn object with ID '{name}'.");
+            }
+        }
+
+    }
+}

--- a/CorgEng.Tests/ContentLoadingTests/ContentLoadingTests.cs
+++ b/CorgEng.Tests/ContentLoadingTests/ContentLoadingTests.cs
@@ -25,6 +25,7 @@ namespace CorgEng.Tests.ContentLoadingTests
         [TestMethod]
         public void TestContentLoading()
         {
+            ConsoleLogger.ExceptionCount = 0;
             EntityLoader.LoadEntities();
             Assert.AreEqual(0, ConsoleLogger.ExceptionCount, "An exception occured during entity loading. See logs for details.");
             //Spawn everything to test spawning

--- a/CorgEng.Tests/ContentLoadingTests/dicttest.xml
+++ b/CorgEng.Tests/ContentLoadingTests/dicttest.xml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Entities>
+
+  <Dictionary id="test_basic_dictionary" keyType="Int32" valueType="Int32">
+    <Element>
+      <Key createdType="Int32">50</Key>
+      <Value createdType="Int32">50</Value>
+    </Element>
+    <Element>
+      <Key createdType="Int32">1562</Key>
+      <Value createdType="Int32">3889</Value>
+    </Element>
+    <Element>
+      <Key createdType="Int32">-5267</Key>
+      <Value createdType="Int32">99</Value>
+    </Element>
+  </Dictionary>
+
+  <Dictionary id="test_supertype_dictionary" keyType="Object" valueType="Int32">
+    <Element>
+      <Key createdType="Int32">50</Key>
+      <Value createdType="Int32">50</Value>
+    </Element>
+    <Element>
+      <Key createdType="Int32">1562</Key>
+      <Value createdType="Int32">3889</Value>
+    </Element>
+    <Element>
+      <Key createdType="Int32">-5267</Key>
+      <Value createdType="Int32">99</Value>
+    </Element>
+  </Dictionary>
+  
+</Entities>
+ 

--- a/CorgEng.Tests/CorgEng.Tests.csproj
+++ b/CorgEng.Tests/CorgEng.Tests.csproj
@@ -56,6 +56,9 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
+    <None Update="ContentLoadingTests\dicttest.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="UserInterfaceTests\UnitTests\Content\UserInterfaceButton.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/CorgEng.Tests/NetworkingTests/ClientAddressTests.cs
+++ b/CorgEng.Tests/NetworkingTests/ClientAddressTests.cs
@@ -34,6 +34,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
+        [Timeout(10000)]
         public void TestHashing()
         {
             IClient dummyClient = GetDummyClient();
@@ -79,6 +80,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
+        [Timeout(10000)]
         public void TestEquality()
         {
             IClient dummyClient = GetDummyClient();
@@ -94,6 +96,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
+        [Timeout(10000)]
         public unsafe void TestEnablingFlag()
         {
             IClientAddress flagTest = ClientAddressFactory.CreateAddress(0, GetDummyClient());
@@ -106,6 +109,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
+        [Timeout(10000)]
         public unsafe void TestDisablingFlag()
         {
             IClientAddress flagTest = ClientAddressFactory.CreateAddress(0, GetDummyClient());
@@ -119,6 +123,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
+        [Timeout(10000)]
         public unsafe void TestAddressGetting()
         {
             Assert.IsNotNull(ClientAddressingTable, "Dependency injection failed");
@@ -163,6 +168,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
+        [Timeout(10000)]
         public unsafe void TestEveryone()
         {
             Assert.IsNotNull(ClientAddressingTable, "Dependency injection failed");

--- a/CorgEng.Tests/NetworkingTests/NetworkingTest.cs
+++ b/CorgEng.Tests/NetworkingTests/NetworkingTest.cs
@@ -59,7 +59,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
-        //[Timeout(3000)]
+        [Timeout(3000)]
         public void TestNetworkConnection()
         {
             if (TestRunning)
@@ -228,7 +228,7 @@ namespace CorgEng.Tests.NetworkingTests
         /// events will be duplicated. We need to make sure we recieve 2 events.
         /// </summary>
         [TestMethod]
-        //[Timeout(3000)]
+        [Timeout(3000)]
         public void TestGlobalNetworkedEvent()
         {
             if (TestRunning)

--- a/CorgEng.Tests/NetworkingTests/PrototypeTests.cs
+++ b/CorgEng.Tests/NetworkingTests/PrototypeTests.cs
@@ -62,6 +62,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
+        [Timeout(10000)]
         public void TestPrototypes()
         {
             bool success = false;

--- a/CorgEng.Tests/NetworkingTests/SerializationTest.cs
+++ b/CorgEng.Tests/NetworkingTests/SerializationTest.cs
@@ -27,6 +27,7 @@ namespace CorgEng.Tests.NetworkingTests
         private static ILogger Logger;
 
         [TestMethod]
+        [Timeout(10000)]
         public void TestComponentSerialization()
         {
             //Give it a seed, so tests are repeatable
@@ -145,6 +146,7 @@ namespace CorgEng.Tests.NetworkingTests
         }
 
         [TestMethod]
+        [Timeout(10000)]
         public void TestEventSerialization()
         {
             //Give it a seed, so tests are repeatable


### PR DESCRIPTION
You can now define dictionaries withing the content loading structure.

![image](https://user-images.githubusercontent.com/26465327/190625693-15b8f22a-dfec-481b-8ded-e4adfe3be6aa.png)

The return type of the key value pairs will be infered from the types defined as attributes for the dictionary nodes.