### PR TITLE
Time control

### DIFF
--- a/CorgEng.AiBehaviour/BehaviourManager.cs
+++ b/CorgEng.AiBehaviour/BehaviourManager.cs
@@ -35,6 +35,11 @@ namespace CorgEng.AiBehaviour
         }
 
         /// <summary>
+        /// Currently running action
+        /// </summary>
+        public IBehaviourAction? CurrentAction { get; set; }
+
+        /// <summary>
         /// The behaviour managers permanent memory
         /// </summary>
         private Dictionary<string, object> permanentMemoryStore = new Dictionary<string, object>();

--- a/CorgEng.EntityComponentSystem/Systems/ProcessingSystem.cs
+++ b/CorgEng.EntityComponentSystem/Systems/ProcessingSystem.cs
@@ -46,6 +46,12 @@ namespace CorgEng.EntityComponentSystem.Systems
         private bool continued = false;
 
         /// <summary>
+        /// Multiplier for delta time, allows to slow or speed up processing
+        /// events, for example if you have time control elements.
+        /// </summary>
+        public static double DeltaTimeMultiplier { get; set; } = 1;
+
+        /// <summary>
         /// Override initial behaviour to also be able to handle processing at regular intervals
         /// </summary>
         protected override void SystemThread()
@@ -73,7 +79,7 @@ namespace CorgEng.EntityComponentSystem.Systems
                     //Do the process
                     try
                     {
-                        currentRun.Current(deltaTime);
+                        currentRun.Current(deltaTime * DeltaTimeMultiplier);
                     }
                     catch (Exception e)
                     {

--- a/CorgEng.GenericInterfaces/AiBehaviours/IBehaviourAction.cs
+++ b/CorgEng.GenericInterfaces/AiBehaviours/IBehaviourAction.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.GenericInterfaces.AiBehaviours
+{
+    public interface IBehaviourAction
+    {
+
+        bool Failed { get; }
+
+        bool Completed { get; }
+
+        /// <summary>
+        /// Perform the action with respect to time.
+        /// </summary>
+        /// <param name="behaviourManager"></param>
+        /// <param name="deltaTime"></param>
+        /// <returns>Returns true if the action was completed, false if it needs to continue</returns>
+        void PerformAction(IBehaviourManager behaviourManager, double deltaTime);
+
+    }
+}

--- a/CorgEng.GenericInterfaces/AiBehaviours/IBehaviourManager.cs
+++ b/CorgEng.GenericInterfaces/AiBehaviours/IBehaviourManager.cs
@@ -33,6 +33,11 @@ namespace CorgEng.GenericInterfaces.AiBehaviours
         Task Process();
 
         /// <summary>
+        /// The currently performing action
+        /// </summary>
+        IBehaviourAction? CurrentAction { get; set; }
+
+        /// <summary>
         /// Set the memory value
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/CorgEng.GenericInterfaces/UtilityTypes/IVector.cs
+++ b/CorgEng.GenericInterfaces/UtilityTypes/IVector.cs
@@ -23,6 +23,8 @@ namespace CorgEng.GenericInterfaces.UtilityTypes
 
         float Length();
 
+        float DistanceTo(IVector<T> other);
+
         T DotProduct(IVector<T> other);
 
         IVector<T> Copy();

--- a/CorgEng.UtilityTypes/Vectors/Vector.cs
+++ b/CorgEng.UtilityTypes/Vectors/Vector.cs
@@ -451,5 +451,16 @@ namespace CorgEng.UtilityTypes.Vectors
                     binaryWriter.Seek(Marshal.SizeOf(value), SeekOrigin.Current);
             }
         }
+
+        public float DistanceTo(IVector<T> other)
+        {
+            Vector<T> otherCopy = new Vector<T>(new T[other.Dimensions]);
+            for (int i = 0; i < other.Dimensions; i++)
+            {
+                otherCopy[i] = other[i];
+            }
+            return (otherCopy - this).Length();
+        }
+
     }
 }


### PR DESCRIPTION
Implements time control.
AI behaviour thinking and acting is now seperated into 2 different sections, the thinking happens on a processing system which waits for the actions to complete. Actions happen on another processing system that takes delta time into account, allowing time to control how fast pawns move.

ProcessingSystem.DeltaTimeMultiplier allows for modification of time, by artifically modifying the time between fires.
If it is set to 2, subsystems will be told to account for 2 process fires in the space of 1, effectively doubling the speed of time.