### PR TITLE
Refactors entity initialisation & better event triggered exceptions

### DIFF
--- a/AutoMap/AutoMap.cs
+++ b/AutoMap/AutoMap.cs
@@ -3,6 +3,7 @@ using CorgEng.Core;
 using CorgEng.Core.Dependencies;
 using CorgEng.EntityComponentSystem.Entities;
 using CorgEng.EntityComponentSystem.Implementations.Transform;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Rendering.Cameras.Isometric;
 using System;
 using System.Collections.Generic;
@@ -18,6 +19,9 @@ namespace AutoMap
         [UsingDependency]
         private static IIsometricCameraFactory isometricCameraFactory;
 
+        [UsingDependency]
+        private static IEntityFactory EntityFactory;
+
         public static void Main(string[] args)
         {
             //Load the application config
@@ -31,10 +35,11 @@ namespace AutoMap
             IIsometricCamera camera = isometricCameraFactory.CreateCamera();
 
             //Create the entity to hold and move the camera
-            Entity mainCameraEntity = new Entity();
-            mainCameraEntity.AddComponent(new TransformComponent());
-            //mainCameraEntity.AddComponent(new PlayerMovementComponent());
-            //mainCameraEntity.AddComponent(new CameraComponent(camera));
+            EntityFactory.CreateEmptyEntity((mainCameraEntity) => {
+                mainCameraEntity.AddComponent(new TransformComponent());
+                //mainCameraEntity.AddComponent(new PlayerMovementComponent());
+                //mainCameraEntity.AddComponent(new CameraComponent(camera));
+            });
 
             //Set the main camera
             CorgEngMain.SetMainCamera(camera);

--- a/CorgEng.ContentLoading/CorgEng.ContentLoading.csproj
+++ b/CorgEng.ContentLoading/CorgEng.ContentLoading.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\CorgEng.Core\CorgEng.Core.csproj" />
-    <ProjectReference Include="..\CorgEng.DependencyInjection\CorgEng.DependencyInjection.csproj" />
+    <ProjectReference Include="..\CorgEng.EntityComponentSystem\CorgEng.EntityComponentSystem.csproj" />
     <ProjectReference Include="..\CorgEng.GenericInterfaces\CorgEng.GenericInterfaces.csproj" />
     <ProjectReference Include="..\CorgEng.UtilityTypes\CorgEng.UtilityTypes.csproj" />
   </ItemGroup>

--- a/CorgEng.ContentLoading/EntityCreator.cs
+++ b/CorgEng.ContentLoading/EntityCreator.cs
@@ -1,5 +1,7 @@
 ﻿using CorgEng.Core.Dependencies;
 using CorgEng.DependencyInjection.Dependencies;
+using CorgEng.EntityComponentSystem.Events;
+using CorgEng.EntityComponentSystem.Events.Events;
 using CorgEng.GenericInterfaces.ContentLoading;
 using CorgEng.GenericInterfaces.ContentLoading.DefinitionNodes;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
@@ -32,13 +34,13 @@ namespace CorgEng.ContentLoading
         /// <param name="entityName"></param>
         /// <returns></returns>
         /// <exception cref="Exception"></exception>
-        public IEntity CreateEntity(string entityName)
+        public IEntity CreateEntity(string entityName, Action<IEntity> preInitialisationEvents)
         {
             try
             {
                 if (EntityNodesByName.ContainsKey(entityName))
                 {
-                    IEntity createdEntity = EntityNodesByName[entityName].CreateEntity();
+                    IEntity createdEntity = EntityNodesByName[entityName].CreateEntity(preInitialisationEvents);
                     createdEntity.DefinitionName = entityName;
                     return createdEntity;
                 }

--- a/CorgEng.Core/Dependencies/UsingDependencyAttribute.cs
+++ b/CorgEng.Core/Dependencies/UsingDependencyAttribute.cs
@@ -3,8 +3,8 @@ using System;
 
 namespace CorgEng.Core.Dependencies
 {
-    [MeansImplicitUse(ImplicitUseKindFlags.Assign)]
-    [UsedImplicitly(ImplicitUseKindFlags.Assign)]
+    [MeansImplicitUse(ImplicitUseKindFlags.Assign | ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
+    [UsedImplicitly(ImplicitUseKindFlags.Assign | ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
     [AttributeUsage(AttributeTargets.Field)]
     public class UsingDependencyAttribute : Attribute
     {

--- a/CorgEng.EntityComponentSystem/Components/Component.cs
+++ b/CorgEng.EntityComponentSystem/Components/Component.cs
@@ -55,9 +55,9 @@ namespace CorgEng.EntityComponentSystem.Components
                 }
                 List<SystemEventHandlerDelegate> systemEventHandlers = RegisteredSystemSignalHandlers[key];
                 //Create a lambda function that injects this component and relays it to the system
-                InternalSignalHandleDelegate componentInjectionLambda = (IEntity entity, IEvent signal, bool synchronous) => {
+                InternalSignalHandleDelegate componentInjectionLambda = (IEntity entity, IEvent signal, bool synchronous, string callingFile, string callingMember, int callingLine) => {
                     foreach(SystemEventHandlerDelegate systemEventHandler in systemEventHandlers)
-                        systemEventHandler.Invoke(entity, this, signal, synchronous);
+                        systemEventHandler.Invoke(entity, this, signal, synchronous, callingFile, callingMember, callingLine);
                 };
                 lock (componentInjectionLambdas)
                 {
@@ -71,9 +71,13 @@ namespace CorgEng.EntityComponentSystem.Components
                 else
                     parent.EventListeners.Add(eventType, new List<InternalSignalHandleDelegate>() { componentInjectionLambda });
             }
-            //Send the component added event
-            ComponentAddedEvent componentAddedEvent = new ComponentAddedEvent(this);
-            componentAddedEvent.Raise(parent);
+            //Send component added event if already initialised
+            if ((parent.EntityFlags & EntityFlags.INITIALISED) != 0)
+            {
+                //Send the component added event
+                ComponentAddedEvent componentAddedEvent = new ComponentAddedEvent(this);
+                componentAddedEvent.Raise(parent);
+            }
         }
 
         /// <summary>

--- a/CorgEng.EntityComponentSystem/Components/ComponentExtensions.cs
+++ b/CorgEng.EntityComponentSystem/Components/ComponentExtensions.cs
@@ -48,11 +48,11 @@ namespace CorgEng.EntityComponentSystem.Components
                 }
                 List<SystemEventHandlerDelegate> systemEventHandlers = RegisteredSystemSignalHandlers[key];
                 //Create a lambda function that injects this component and relays it to the system
-                InternalSignalHandleDelegate componentInjectionLambda = (IEntity entity, IEvent signal, bool synchronous) =>
+                InternalSignalHandleDelegate componentInjectionLambda = (IEntity entity, IEvent signal, bool synchronous, string callingFile, string callingMember, int callingLine) =>
                 {
                     for (int i = systemEventHandlers.Count - 1; i >= 0; i--)
                     {
-                        systemEventHandlers[i].Invoke(entity, component, signal, synchronous);
+                        systemEventHandlers[i].Invoke(entity, component, signal, synchronous, callingFile, callingMember, callingLine);
                     }
                 };
                 if (!componentInjectionLambdas.ContainsKey(component))

--- a/CorgEng.EntityComponentSystem/CorgEng.EntityComponentSystem.csproj
+++ b/CorgEng.EntityComponentSystem/CorgEng.EntityComponentSystem.csproj
@@ -20,7 +20,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CorgEng.ContentLoading\CorgEng.ContentLoading.csproj" />
     <ProjectReference Include="..\CorgEng.Core\CorgEng.Core.csproj" />
     <ProjectReference Include="..\CorgEng.GenericInterfaces\CorgEng.GenericInterfaces.csproj" />
     <ProjectReference Include="..\CorgEng.Rendering\CorgEng.Rendering.csproj" />

--- a/CorgEng.EntityComponentSystem/Entities/Entity.cs
+++ b/CorgEng.EntityComponentSystem/Entities/Entity.cs
@@ -17,7 +17,7 @@ namespace CorgEng.EntityComponentSystem.Entities
     public class Entity : IEntity
     {
 
-        internal delegate void InternalSignalHandleDelegate(IEntity entity, IEvent signal, bool synchronous);
+        internal delegate void InternalSignalHandleDelegate(IEntity entity, IEvent signal, bool synchronous, string callingFile, string callingMember, int callingLine);
 
         [UsingDependency]
         private static ILogger Logger;
@@ -26,6 +26,11 @@ namespace CorgEng.EntityComponentSystem.Entities
         /// The identifier for the entity. Used to find a specific entity.
         /// </summary>
         public uint Identifier { get; private set; }
+
+        /// <summary>
+        /// The flags relating to this entity. Indicate if it has been initialised, destroyed etc.
+        /// </summary>
+        public EntityFlags EntityFlags { get; set; } = EntityFlags.NONE;
 
         /// <summary>
         /// List of all components attached to this entity
@@ -53,7 +58,7 @@ namespace CorgEng.EntityComponentSystem.Entities
         /// </summary>
         public string DefinitionName { get; set; }
 
-        public Entity()
+        internal Entity()
         {
             Identifier = EntityManager.GetNewEntityId();
             EntityManager.RegisterEntity(this);
@@ -106,7 +111,7 @@ namespace CorgEng.EntityComponentSystem.Entities
         /// Internal method for handling signals.
         /// </summary>
         /// <param name="signal"></param>
-        public void HandleSignal(IEvent signal, bool synchronous = false)
+        public void HandleSignal(IEvent signal, bool synchronous, string callingFile, string callingMember, int callingLine)
         {
             //Verify that this signal is being listened for
             if (EventListeners == null)
@@ -120,7 +125,7 @@ namespace CorgEng.EntityComponentSystem.Entities
             for (int i = signalHandleDelegates.Count - 1; i >= 0; i = Math.Min(i - 1, signalHandleDelegates.Count - 1))
             {
                 InternalSignalHandleDelegate internalSignalHandler = signalHandleDelegates[i];
-                internalSignalHandler.Invoke(this, signal, synchronous);
+                internalSignalHandler.Invoke(this, signal, synchronous, callingFile, callingMember, callingLine);
             }
         }
 

--- a/CorgEng.EntityComponentSystem/Entities/EntityFactory.cs
+++ b/CorgEng.EntityComponentSystem/Entities/EntityFactory.cs
@@ -1,4 +1,6 @@
 ﻿using CorgEng.DependencyInjection.Dependencies;
+using CorgEng.EntityComponentSystem.Events;
+using CorgEng.EntityComponentSystem.Events.Events;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using System;
 using System.Collections.Generic;
@@ -12,10 +14,21 @@ namespace CorgEng.EntityComponentSystem.Entities
     internal class EntityFactory : IEntityFactory
     {
 
-        public IEntity CreateEmptyEntity()
+        public IEntity CreateEmptyEntity(Action<IEntity> preInitialisationEvents)
+        {
+            //Create the blank entity.
+            IEntity createdEntity = new Entity();
+            //Run any events that need to happen before initialisation
+            preInitialisationEvents?.Invoke(createdEntity);
+            //Raise the initialise event
+            new InitialiseEvent().Raise(createdEntity, true);
+            //Return the entity that was created
+            return createdEntity;
+        }
+
+        public IEntity CreateUninitialisedEntity()
         {
             return new Entity();
         }
-
     }
 }

--- a/CorgEng.EntityComponentSystem/Entities/EntityManager.cs
+++ b/CorgEng.EntityComponentSystem/Entities/EntityManager.cs
@@ -72,6 +72,10 @@ namespace CorgEng.EntityComponentSystem.Entities
         /// </summary>
         internal static void Delete(this IEntity entity)
         {
+            if ((entity.EntityFlags & EntityFlags.DESTROYED) != 0)
+            {
+                throw new Exception("Attempting to delete an already deleted entity.");
+            }
             Interlocked.Increment(ref DeletionCount);
             RemoveEntity(entity);
             //Remove all components
@@ -79,6 +83,8 @@ namespace CorgEng.EntityComponentSystem.Entities
             {
                 entity.RemoveComponent(entity.Components[i], false);
             }
+            //Mark the entity as destroyed
+            entity.EntityFlags |= EntityFlags.DESTROYED;
             //Logger.WriteLine($"Entity deletion triggered. {GarbageCollectionCount}/{DeletionCount}", LogType.TEMP);
         }
 

--- a/CorgEng.EntityComponentSystem/Events/EventExtensions.cs
+++ b/CorgEng.EntityComponentSystem/Events/EventExtensions.cs
@@ -9,6 +9,7 @@ using CorgEng.GenericInterfaces.Networking.Packets;
 using CorgEng.GenericInterfaces.Networking.VersionSync;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using static CorgEng.EntityComponentSystem.Entities.Entity;
 using static CorgEng.EntityComponentSystem.Systems.EntitySystem;
@@ -28,24 +29,36 @@ namespace CorgEng.EntityComponentSystem.Events
         /// <summary>
         /// Raise this event against a specified target
         /// </summary>
-        public static void Raise(this IEvent signal, IEntity target, bool synchronous = false)
+        public static void Raise(
+            this IEvent signal,
+            IEntity target,
+            bool synchronous = false,
+            [CallerFilePath] string callingFile = "",
+            [CallerMemberName] string callingMember = "",
+            [CallerLineNumber] int callingLine = 0)
         {
             Logger.WriteLine($"Event raised {signal}", LogType.DEBUG_EVERYTHING);
             //Handle the signal
-            target.HandleSignal(signal, synchronous);
+            target.HandleSignal(signal, synchronous, callingFile, callingMember, callingLine);
         }
 
         /// <summary>
         /// Raise this event and network it
         /// </summary>
-        public static void Raise(this INetworkedEvent signal, IEntity target, bool synchronous = false)
+        public static void Raise(
+            this INetworkedEvent signal,
+            IEntity target,
+            bool synchronous = false,
+            [CallerFilePath] string callingFile = "",
+            [CallerMemberName] string callingMember = "",
+            [CallerLineNumber] int callingLine = 0)
         {
             Logger.WriteLine($"Networked event raised {signal}", LogType.DEBUG_EVERYTHING);
             //Handle the signal
-            target.HandleSignal(signal, synchronous);
+            target.HandleSignal(signal, synchronous, callingFile, callingMember, callingLine);
             //Inform the entity that networked event was raised
             //Skip directly to signal handling
-            target.HandleSignal(new NetworkedEventRaisedEvent(signal));
+            target.HandleSignal(new NetworkedEventRaisedEvent(signal), false, callingFile, callingMember, callingLine);
         }
 
         /// <summary>
@@ -53,7 +66,12 @@ namespace CorgEng.EntityComponentSystem.Events
         /// Use of synchronous is recommended only when there is no other options
         /// as it will freeze the running thread
         /// </summary>
-        public static void RaiseGlobally(this IEvent signal, bool synchronous = false)
+        public static void RaiseGlobally(
+            this IEvent signal,
+            bool synchronous = false,
+            [CallerFilePath] string callingFile = "",
+            [CallerMemberName] string callingMember = "",
+            [CallerLineNumber] int callingLine = 0)
         {
             Logger.WriteLine($"Event raised {signal}", LogType.DEBUG_EVERYTHING);
             //Check if we have any registered signals
@@ -66,14 +84,20 @@ namespace CorgEng.EntityComponentSystem.Events
             {
                 List<SystemEventHandlerDelegate> systemEventHandlers = RegisteredSystemSignalHandlers[key];
                 for (int i = systemEventHandlers.Count - 1; i >= 0; i--)
-                    systemEventHandlers[i].Invoke(null, null, signal, synchronous);
+                    systemEventHandlers[i].Invoke(null, null, signal, synchronous, callingFile, callingMember, callingLine);
             }
         }
 
         /// <summary>
         /// Raise the event globally
         /// </summary>
-        public static void RaiseGlobally(this INetworkedEvent signal, bool sourcedLocally = true, bool synchronous = false)
+        public static void RaiseGlobally(
+            this INetworkedEvent signal,
+            bool sourcedLocally = true,
+            bool synchronous = false,
+            [CallerFilePath] string callingFile = "",
+            [CallerMemberName] string callingMember = "",
+            [CallerLineNumber] int callingLine = 0)
         {
             Logger.WriteLine($"Network event raised {signal}", LogType.DEBUG_EVERYTHING);
             //Check if we have any registered signals
@@ -86,7 +110,7 @@ namespace CorgEng.EntityComponentSystem.Events
             {
                 List<SystemEventHandlerDelegate> systemEventHandlers = RegisteredSystemSignalHandlers[key];
                 for (int i = systemEventHandlers.Count - 1; i >= 0; i--)
-                    systemEventHandlers[i].Invoke(null, null, signal, synchronous);
+                    systemEventHandlers[i].Invoke(null, null, signal, synchronous, callingFile, callingMember, callingLine);
             }
             //Don't relay messages coming from other clients already
             if (!sourcedLocally)
@@ -105,7 +129,7 @@ namespace CorgEng.EntityComponentSystem.Events
             }
             List<SystemEventHandlerDelegate> networkedEventHandlers = RegisteredSystemSignalHandlers[networkKey];
             for (int i = networkedEventHandlers.Count - 1; i >= 0; i--)
-                networkedEventHandlers[i].Invoke(null, null, new NetworkedEventRaisedEvent(signal), synchronous);
+                networkedEventHandlers[i].Invoke(null, null, new NetworkedEventRaisedEvent(signal), synchronous, callingFile, callingMember, callingLine);
         }
 
     }

--- a/CorgEng.EntityComponentSystem/Events/Events/InitialiseEvent.cs
+++ b/CorgEng.EntityComponentSystem/Events/Events/InitialiseEvent.cs
@@ -1,0 +1,16 @@
+﻿using CorgEng.GenericInterfaces.EntityComponentSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.EntityComponentSystem.Events.Events
+{
+    /// <summary>
+    /// Called after an entity has been fully initialised, with the correct transform position.
+    /// </summary>
+    public class InitialiseEvent : IEvent
+    {
+    }
+}

--- a/CorgEng.EntityComponentSystem/Implementations/Initialisation/EntityInitialisationSystem.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Initialisation/EntityInitialisationSystem.cs
@@ -1,0 +1,40 @@
+﻿using CorgEng.EntityComponentSystem.Entities;
+using CorgEng.EntityComponentSystem.Events.Events;
+using CorgEng.EntityComponentSystem.Implementations.Deletion;
+using CorgEng.EntityComponentSystem.Systems;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.EntityComponentSystem.Implementations.Initialisation
+{
+    internal class EntityInitialisationSystem : EntitySystem
+    {
+
+        public override EntitySystemFlags SystemFlags => EntitySystemFlags.HOST_SYSTEM | EntitySystemFlags.CLIENT_SYSTEM;
+
+        public override void SystemSetup()
+        {
+            RegisterLocalEvent<DeleteableComponent, InitialiseEvent>(OnInitialisation);
+        }
+
+        private void OnInitialisation(IEntity entity, DeleteableComponent deletableComponent, InitialiseEvent initialiseEvent)
+        {
+            //Doing something extremely weird
+            if ((entity.EntityFlags & EntityFlags.DESTROYED) != 0)
+            {
+                throw new Exception("Attempting to initialise a destroyed entity, something weird is being done.");
+            }
+            if ((entity.EntityFlags & EntityFlags.INITIALISED) != 0)
+            {
+                throw new Exception("Attempted to initialise an already initialised entity.");
+            }
+            //Toggle the flag on
+            entity.EntityFlags |= EntityFlags.INITIALISED;
+        }
+
+    }
+}

--- a/CorgEng.EntityComponentSystem/Systems/InvokationEvent.cs
+++ b/CorgEng.EntityComponentSystem/Systems/InvokationEvent.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.EntityComponentSystem.Systems
+{
+    public class InvokationAction
+    {
+
+        /// <summary>
+        /// The action to invoke
+        /// </summary>
+        public Action Action { get; }
+
+        public string CallingFile { get; }
+
+        public string CallingMemberName { get; }
+
+        public int CallingLineNumber { get; }
+
+        public InvokationAction(Action action, string callingFile, string callingMemberName, int callingLineNumber)
+        {
+            Action = action;
+            CallingFile = callingFile;
+            CallingMemberName = callingMemberName;
+            CallingLineNumber = callingLineNumber;
+        }
+    }
+}

--- a/CorgEng.EntityComponentSystem/Systems/ProcessingSystem.cs
+++ b/CorgEng.EntityComponentSystem/Systems/ProcessingSystem.cs
@@ -94,16 +94,16 @@ namespace CorgEng.EntityComponentSystem.Systems
                     }
                 }
                 //Allocate time to processing signal handles
-                Action current;
+                InvokationAction current;
                 while (invokationQueue.TryDequeue(out current))
                 {
                     try
                     {
-                        current();
+                        current.Action();
                     }
                     catch (Exception e)
                     {
-                        Logger?.WriteLine(e, LogType.ERROR);
+                        Logger?.WriteLine($"Event Called From: {current.CallingMemberName}:{current.CallingLineNumber} in {current.CallingFile}\n{e}", LogType.ERROR);
                     }
                 }
                 //If we completed processing, wait for the specified time, or until another signal handler comes in

--- a/CorgEng.Example.Server/Program.cs
+++ b/CorgEng.Example.Server/Program.cs
@@ -41,6 +41,9 @@ namespace CorgEng.Example.Server
         [UsingDependency]
         private static IPrototypeManager PrototypeManager;
 
+        [UsingDependency]
+        private static IEntityFactory EntityFactory;
+
 #if DEBUG_RENDERING
         [UsingDependency]
         private static IIsometricCameraFactory IsometricCameraFactory;
@@ -71,14 +74,15 @@ namespace CorgEng.Example.Server
             {
                 for (int y = -1; y <= 1; y++)
                 {
-                    IEntity testingEntity = new Entity();
-                    //Add components
-                    testingEntity.AddComponent(new NetworkTransformComponent());
-                    testingEntity.AddComponent(new SpriteRenderComponent());
-                    //Update the entity
-                    new SetPositionEvent(new Vector<float>(x, y)).Raise(testingEntity);
-                    new SetSpriteEvent(IconFactory.CreateIcon("human.ghost", 5)).Raise(testingEntity);
-                    new SetSpriteRendererEvent(1).Raise(testingEntity);
+                    EntityFactory.CreateEmptyEntity(testingEntity => {
+                        //Add components
+                        testingEntity.AddComponent(new NetworkTransformComponent());
+                        testingEntity.AddComponent(new SpriteRenderComponent());
+                        //Update the entity
+                        new SetPositionEvent(new Vector<float>(x, y)).Raise(testingEntity);
+                        new SetSpriteEvent(IconFactory.CreateIcon("human.ghost", 5)).Raise(testingEntity);
+                        new SetSpriteRendererEvent(1).Raise(testingEntity);
+                    });
                 }
             }
             //Set the default player prototype
@@ -103,15 +107,16 @@ namespace CorgEng.Example.Server
 
         private static void SetPlayerPrototype()
         {
-            IEntity playerPrototype = new Entity();
-            playerPrototype.AddComponent(new ClientComponent());
-            playerPrototype.AddComponent(new NetworkTransformComponent());
-            playerPrototype.AddComponent(new SpriteRenderComponent() { Sprite = IconFactory.CreateIcon("human.ghost", 5), SpriteRendererIdentifier = 1 });
-            playerPrototype.AddComponent(new PlayerMovementComponent());
-            playerPrototype.AddComponent(new DeleteableComponent());
-            IPrototype prototype = PrototypeManager.GetPrototype(playerPrototype);
-            NetworkingServer.SetClientPrototype(prototype);
-            new DeleteEntityEvent().Raise(playerPrototype);
+            EntityFactory.CreateEmptyEntity(playerPrototype => {
+                playerPrototype.AddComponent(new ClientComponent());
+                playerPrototype.AddComponent(new NetworkTransformComponent());
+                playerPrototype.AddComponent(new SpriteRenderComponent() { Sprite = IconFactory.CreateIcon("human.ghost", 5), SpriteRendererIdentifier = 1 });
+                playerPrototype.AddComponent(new PlayerMovementComponent());
+                playerPrototype.AddComponent(new DeleteableComponent());
+                IPrototype prototype = PrototypeManager.GetPrototype(playerPrototype);
+                NetworkingServer.SetClientPrototype(prototype);
+                new DeleteEntityEvent().Raise(playerPrototype);
+            });
         }
 
     }

--- a/CorgEng.Example/Program.cs
+++ b/CorgEng.Example/Program.cs
@@ -1,41 +1,11 @@
 ﻿using CorgEng.Core;
 using CorgEng.Core.Dependencies;
-using CorgEng.Core.Rendering;
-using CorgEng.DependencyInjection;
-using CorgEng.DependencyInjection.Injection;
-using CorgEng.EntityComponentSystem;
-using CorgEng.EntityComponentSystem.Entities;
-using CorgEng.EntityComponentSystem.Events;
-using CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRendering;
-using CorgEng.EntityComponentSystem.Implementations.Transform;
-using CorgEng.Example.Common.Components.Camera;
-using CorgEng.Example.Components.PlayerMovement;
 using CorgEng.Example.Modules.CameraScroll;
 using CorgEng.Example.Shared.RenderCores;
-using CorgEng.GenericInterfaces.Font.Fonts;
-using CorgEng.GenericInterfaces.Networking.Networking;
 using CorgEng.GenericInterfaces.Networking.Networking.Client;
-using CorgEng.GenericInterfaces.Networking.Networking.Server;
-using CorgEng.GenericInterfaces.Rendering;
 using CorgEng.GenericInterfaces.Rendering.Cameras.Isometric;
-using CorgEng.GenericInterfaces.Rendering.Renderers.SpriteRendering;
-using CorgEng.GenericInterfaces.Rendering.RenderObjects.SpriteRendering;
-using CorgEng.GenericInterfaces.Rendering.Shaders;
-using CorgEng.GenericInterfaces.Rendering.Text;
-using CorgEng.GenericInterfaces.Rendering.Textures;
-using CorgEng.GenericInterfaces.UserInterface.Components;
-using CorgEng.GenericInterfaces.UserInterface.Generators;
-using CorgEng.UtilityTypes;
-using CorgEng.UtilityTypes.Vectors;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
-using static OpenGL.Gl;
+
 
 namespace CorgEng.Example
 {

--- a/CorgEng.GenericInterfaces/ContentLoading/IEntityCreator.cs
+++ b/CorgEng.GenericInterfaces/ContentLoading/IEntityCreator.cs
@@ -1,4 +1,5 @@
 ﻿using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.UtilityTypes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -16,8 +17,8 @@ namespace CorgEng.GenericInterfaces.ContentLoading
         /// Create an entity with the specific one
         /// </summary>
         /// <param name="entityName"></param>
-        /// <returns></returns>
-        IEntity CreateEntity(string entityName);
+        /// <returns>Returns an uninitialised entity.</returns>
+        IEntity CreateEntity(string entityName, Action<IEntity> preInitialisationEvents);
 
         /// <summary>
         /// Create an object with the specified identifier.

--- a/CorgEng.GenericInterfaces/ContentLoading/IEntityDefinition.cs
+++ b/CorgEng.GenericInterfaces/ContentLoading/IEntityDefinition.cs
@@ -14,7 +14,7 @@ namespace CorgEng.GenericInterfaces.ContentLoading
         /// Create the entity
         /// </summary>
         /// <returns></returns>
-        IEntity CreateEntity();
+        IEntity CreateEntity(Action<IEntity> setupAction);
 
     }
 }

--- a/CorgEng.GenericInterfaces/EntityComponentSystem/EntityFlags.cs
+++ b/CorgEng.GenericInterfaces/EntityComponentSystem/EntityFlags.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.EntityComponentSystem.Entities
+{
+    public enum EntityFlags
+    {
+        /// <summary>
+        /// No flags, default value
+        /// </summary>
+        NONE = 0,
+        /// <summary>
+        /// The entity has been initialised.
+        /// Uninitialised entities will not have components setup properly.
+        /// </summary>
+        INITIALISED = 1 << 0,
+        /// <summary>
+        /// The entity has been destroyed, it should no longer be processing
+        /// or receiving events at this point.
+        /// </summary>
+        DESTROYED = 1 << 1,
+    }
+}

--- a/CorgEng.GenericInterfaces/EntityComponentSystem/IEntity.cs
+++ b/CorgEng.GenericInterfaces/EntityComponentSystem/IEntity.cs
@@ -1,4 +1,5 @@
-﻿using CorgEng.GenericInterfaces.UtilityTypes;
+﻿using CorgEng.EntityComponentSystem.Entities;
+using CorgEng.GenericInterfaces.UtilityTypes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -26,11 +27,16 @@ namespace CorgEng.GenericInterfaces.EntityComponentSystem
         /// </summary>
         uint Identifier { get; }
 
+        /// <summary>
+        /// Flags relating to this entity.
+        /// </summary>
+        EntityFlags EntityFlags { get; set; }
+
         void AddComponent(IComponent component);
 
         void RemoveComponent(IComponent component, bool networked);
 
-        void HandleSignal(IEvent signal, bool synchronous = false);
+        void HandleSignal(IEvent signal, bool synchronous, string callingFile, string callingMember, int callingLine);
 
         /// <summary>
         /// Gets a component of type. This is slow, avoid using it extensively.

--- a/CorgEng.GenericInterfaces/EntityComponentSystem/IEntityFactory.cs
+++ b/CorgEng.GenericInterfaces/EntityComponentSystem/IEntityFactory.cs
@@ -13,7 +13,13 @@ namespace CorgEng.GenericInterfaces.EntityComponentSystem
         /// Creates an empty entity with no components
         /// </summary>
         /// <returns></returns>
-        IEntity CreateEmptyEntity();
+        IEntity CreateEmptyEntity(Action<IEntity> preInitialisationEvents);
+
+        /// <summary>
+        /// Creates an empty entity with no components
+        /// </summary>
+        /// <returns></returns>
+        IEntity CreateUninitialisedEntity();
 
     }
 }

--- a/CorgEng.Networking/Networking/Server/NetworkingServer.cs
+++ b/CorgEng.Networking/Networking/Server/NetworkingServer.cs
@@ -58,6 +58,9 @@ namespace CorgEng.Networking.Networking.Server
         [UsingDependency]
         private static IPrototypeManager PrototypeManager;
 
+        [UsingDependency]
+        private static IEntityFactory EntityFactory;
+
         private static IPrototype DefaultEntityPrototype;
 
         private IPacketQueue PacketQueue;
@@ -108,13 +111,14 @@ namespace CorgEng.Networking.Networking.Server
         public void LoadDefaultPrototype()
         {
             //Set the default prototype
-            IEntity sampleEntity = new Entity();
-            sampleEntity.AddComponent(new NetworkTransformComponent());
-            sampleEntity.AddComponent(new ClientComponent());
-            //Get the prototype
-            DefaultEntityPrototype = PrototypeManager.GetPrototype(sampleEntity, false);
-            //Delete the entity
-            new DeleteEntityEvent().Raise(sampleEntity);
+            EntityFactory.CreateEmptyEntity(sampleEntity => {
+                sampleEntity.AddComponent(new NetworkTransformComponent());
+                sampleEntity.AddComponent(new ClientComponent());
+                //Get the prototype
+                DefaultEntityPrototype = PrototypeManager.GetPrototype(sampleEntity, false);
+                //Delete the entity
+                new DeleteEntityEvent().Raise(sampleEntity);
+            });
         }
 
         public void StartHosting(int port)

--- a/CorgEng.Networking/Networking/Server/NetworkingServer.cs
+++ b/CorgEng.Networking/Networking/Server/NetworkingServer.cs
@@ -117,7 +117,7 @@ namespace CorgEng.Networking.Networking.Server
                 //Get the prototype
                 DefaultEntityPrototype = PrototypeManager.GetPrototype(sampleEntity, false);
                 //Delete the entity
-                new DeleteEntityEvent().Raise(sampleEntity);
+                new DeleteEntityEvent().Raise(sampleEntity, true);
             });
         }
 

--- a/CorgEng.Tests/EntityComponentSystem/ProcessingSystemTest.cs
+++ b/CorgEng.Tests/EntityComponentSystem/ProcessingSystemTest.cs
@@ -1,4 +1,5 @@
-﻿using CorgEng.EntityComponentSystem.Components;
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.EntityComponentSystem.Components;
 using CorgEng.EntityComponentSystem.Entities;
 using CorgEng.EntityComponentSystem.Events;
 using CorgEng.EntityComponentSystem.Systems;
@@ -17,6 +18,9 @@ namespace CorgEng.Tests.EntityComponentSystem
     [TestClass]
     public class ProcessingSystemTest
     {
+
+        [UsingDependency]
+        private static IEntityFactory EntityFactory;
 
         private class TestComponent : Component
         {
@@ -51,7 +55,7 @@ namespace CorgEng.Tests.EntityComponentSystem
             TestSystem testSystem = new TestSystem();
             testSystem.SystemSetup();
             //Create an entity to process
-            IEntity testEntity = new Entity();
+            IEntity testEntity = EntityFactory.CreateEmptyEntity(null);
             TestComponent testComponent = new TestComponent();
             testEntity.AddComponent(testComponent);
             //Start processing

--- a/CorgEng.Tests/EntityComponentSystem/SignalTests.cs
+++ b/CorgEng.Tests/EntityComponentSystem/SignalTests.cs
@@ -110,6 +110,9 @@ namespace CorgEng.Tests.EntityComponentSystem
     public class SignalTests
     {
 
+        [UsingDependency]
+        private static IEntityFactory EntityFactory;
+
         /// <summary>
         /// DONT USE DEPENDNCY INJECTION TO FORCE THIS
         /// </summary>
@@ -151,7 +154,7 @@ namespace CorgEng.Tests.EntityComponentSystem
             Assert.AreEqual(0, handlesReceieved, "INCORRECT TEST CONFIGURATION");
             Logger?.WriteLine($"Current thread: {Thread.CurrentThread.ManagedThreadId}. TestID: {currentTestId}");
             //Create a test entity
-            Entity testEntity = new Entity();
+            IEntity testEntity = EntityFactory.CreateEmptyEntity(null);
             //Add a test component
             TestComponent testComponent = new TestComponent();
             testEntity.AddComponent(testComponent);
@@ -172,7 +175,7 @@ namespace CorgEng.Tests.EntityComponentSystem
             Assert.AreEqual(0, secondaryHandlesReceieved, "INCORRECT TEST CONFIGURATION");
             Logger?.WriteLine($"Current thread: {Thread.CurrentThread.ManagedThreadId}. TestID: {currentTestId}");
             //Create a test entity
-            Entity testEntity = new Entity();
+            IEntity testEntity = EntityFactory.CreateEmptyEntity(null);
             //Add a test component
             TestComponent testComponent = new TestComponent();
             testEntity.AddComponent(testComponent);
@@ -197,7 +200,7 @@ namespace CorgEng.Tests.EntityComponentSystem
             Assert.AreEqual(0, handlesReceieved, "INCORRECT TEST CONFIGURATION");
             Logger?.WriteLine($"Current thread: {Thread.CurrentThread.ManagedThreadId}. TestID: {currentTestId}");
             //Create a test entity
-            Entity testEntity = new Entity();
+            IEntity testEntity = EntityFactory.CreateEmptyEntity(null);
             //Add a test component
             TestComponent testComponent = new TestComponent();
             testEntity.AddComponent(testComponent);
@@ -242,7 +245,7 @@ namespace CorgEng.Tests.EntityComponentSystem
             Assert.AreEqual(0, handlesReceieved, "INCORRECT TEST CONFIGURATION");
             Logger?.WriteLine($"Current thread: {Thread.CurrentThread.ManagedThreadId}. TestID: {currentTestId}");
             //Create a test entity
-            Entity testEntity = new Entity();
+            IEntity testEntity = EntityFactory.CreateEmptyEntity(null);
             //Add a test component
             TestComponent testComponent = new TestComponent();
             testEntity.AddComponent(testComponent);
@@ -263,7 +266,7 @@ namespace CorgEng.Tests.EntityComponentSystem
             Assert.AreEqual(0, handlesReceieved, "INCORRECT TEST CONFIGURATION");
             Logger?.WriteLine($"Current thread: {Thread.CurrentThread.ManagedThreadId}. TestID: {currentTestId}");
             //Create a test entity
-            Entity testEntity = new Entity();
+            IEntity testEntity = EntityFactory.CreateEmptyEntity(null);
             //Add a test component
             TestComponent testComponent = new TestComponent();
             testEntity.AddComponent(testComponent);
@@ -287,7 +290,7 @@ namespace CorgEng.Tests.EntityComponentSystem
             Assert.AreEqual(0, handlesReceieved, "INCORRECT TEST CONFIGURATION");
             Logger?.WriteLine($"Current thread: {Thread.CurrentThread.ManagedThreadId}. TestID: {currentTestId}");
             //Create a test entity
-            Entity testEntity = new Entity();
+            IEntity testEntity = EntityFactory.CreateEmptyEntity(null);
             //Add a test component
             TestComponent testComponent = new TestComponent();
             testEntity.AddComponent(testComponent);

--- a/CorgEng.Tests/NetworkingTests/EntityCommunicatorTests.cs
+++ b/CorgEng.Tests/NetworkingTests/EntityCommunicatorTests.cs
@@ -33,6 +33,9 @@ namespace CorgEng.Tests.NetworkingTests
         [UsingDependency]
         private static ILogger Logger;
 
+        [UsingDependency]
+        private static IEntityFactory EntityFactory;
+
         [TestCleanup]
         public void AfterTest()
         {
@@ -46,7 +49,7 @@ namespace CorgEng.Tests.NetworkingTests
         public void TestEntityCommunication()
         {
             //Alright, connection established. Lets communicate an entity
-            IEntity testEntity = new Entity();
+            IEntity testEntity = EntityFactory.CreateEmptyEntity(null);
             TestComponent testComponent = new TestComponent();
             testComponent.Text = "test";
             testComponent.DontSerialise = 5.31262;

--- a/CorgEng.Tests/NetworkingTests/PrototypeTests.cs
+++ b/CorgEng.Tests/NetworkingTests/PrototypeTests.cs
@@ -43,6 +43,9 @@ namespace CorgEng.Tests.NetworkingTests
     {
 
         [UsingDependency]
+        private static IEntityFactory EntityFactory;
+
+        [UsingDependency]
         private static IPrototypeManager PrototypeManager;
 
         [UsingDependency]
@@ -75,7 +78,7 @@ namespace CorgEng.Tests.NetworkingTests
                 Thread.Sleep(0);
 
             //Create an entity
-            IEntity entity = new Entity();
+            IEntity entity = EntityFactory.CreateEmptyEntity(null);
             TestComponent testComponent = new TestComponent();
             testComponent.Integer = 59;
             testComponent.Text = "Hello World!";

--- a/CorgEng.Tests/Performance/SerialisationPerformance.cs
+++ b/CorgEng.Tests/Performance/SerialisationPerformance.cs
@@ -20,6 +20,9 @@ namespace CorgEng.Tests.Performance
     {
 
         [UsingDependency]
+        private static IEntityFactory EntityFactory;
+
+        [UsingDependency]
         private static IPrototypeManager PrototypeManager;
 
         private const int TEST_TIME = 5000;
@@ -31,7 +34,7 @@ namespace CorgEng.Tests.Performance
             Assert.Inconclusive("Test not executed. Please enable PERFORMANCE_TEST define in order to test performance.");
 #endif
             //Create an entity
-            IEntity entity = new Entity();
+            IEntity entity = EntityFactory.CreateEmptyEntity(null);
             TestComponent testComponent = new TestComponent();
             testComponent.Integer = 59;
             testComponent.Text = "Hello World!";
@@ -64,7 +67,7 @@ namespace CorgEng.Tests.Performance
             Assert.Inconclusive("Test not executed. Please enable PERFORMANCE_TEST define in order to test performance.");
 #endif
             //Create an entity
-            IEntity entity = new Entity();
+            IEntity entity = EntityFactory.CreateEmptyEntity(null);
             TestComponent testComponent = new TestComponent();
             testComponent.Integer = 59;
             testComponent.Text = "Hello World!";
@@ -100,7 +103,7 @@ namespace CorgEng.Tests.Performance
 #endif
 
             //Create an entity
-            IEntity entity = new Entity();
+            IEntity entity = EntityFactory.CreateEmptyEntity(null);
             TestComponent testComponent = new TestComponent();
             testComponent.Integer = 59;
             testComponent.Text = "Hello World!";
@@ -137,7 +140,7 @@ namespace CorgEng.Tests.Performance
 #endif
 
             //Create an entity
-            IEntity entity = new Entity();
+            IEntity entity = EntityFactory.CreateEmptyEntity(null);
             TestComponent testComponent = new TestComponent();
             testComponent.Integer = 59;
             testComponent.Text = "Hello World!";

--- a/CorgEng.UserInterface/UserInterfaceComponents/UserInterfaceComponent.cs
+++ b/CorgEng.UserInterface/UserInterfaceComponents/UserInterfaceComponent.cs
@@ -45,7 +45,7 @@ namespace CorgEng.UserInterface.Components
         /// so we can have a component based user interface model despite
         /// the oversight of not implementing it this way initially
         /// </summary>
-        public IEntity ComponentHolder { get; } = EntityFactory.CreateEmptyEntity();
+        public IEntity ComponentHolder { get; } = EntityFactory.CreateEmptyEntity(null);
 
         /// <summary>
         /// Is this component fullscreen?


### PR DESCRIPTION
Refactors entity initialisation
 - Creating an empty entity now takes a pre initialisation function which will be executed before initilisation is called.
 - You can no longer create an entity via the new keyword.
 - All forms of entity creation excluding createUninitialisedEntity will create an initialised entity.
 - You can now register for the initialisation event to run code after all components have been added and set up. (Objects will be translated to their correct location!)
 - Exceptions that occur on a system will now output the calling file and line of the event that caused the exception to happen.