### PR TITLE
Creates the contents module

### DIFF
--- a/CorgEng.Contents/Components/ContainedComponent.cs
+++ b/CorgEng.Contents/Components/ContainedComponent.cs
@@ -1,0 +1,24 @@
+﻿using CorgEng.EntityComponentSystem.Components;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.Contents.Components
+{
+    public class ContainedComponent : Component
+    {
+
+        /// <summary>
+        /// The entity that we are contained inside.
+        /// </summary>
+        public IEntity Holder { get; internal set; }
+
+        public ContainedComponent(IEntity holder)
+        {
+            Holder = holder;
+        }
+    }
+}

--- a/CorgEng.Contents/Components/ContentsComponent.cs
+++ b/CorgEng.Contents/Components/ContentsComponent.cs
@@ -1,0 +1,25 @@
+﻿using CorgEng.EntityComponentSystem.Components;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.Contents.Components
+{
+    public class ContentsComponent : Component
+    {
+
+        /// <summary>
+        /// The entities that are currently stored inside of us.
+        /// </summary>
+        public List<IEntity> EntitiesInContents { get; } = new List<IEntity>();
+
+        /// <summary>
+        /// What to do with the children when we are destroyed.
+        /// </summary>
+        public ParentDestroyReaction DestroyReaction { get; set; } = ParentDestroyReaction.DESTROY_CHILDREN;
+
+    }
+}

--- a/CorgEng.Contents/CorgEng.Contents.csproj
+++ b/CorgEng.Contents/CorgEng.Contents.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CorgEng.EntityComponentSystem\CorgEng.EntityComponentSystem.csproj" />
+    <ProjectReference Include="..\CorgEng.GenericInterfaces\CorgEng.GenericInterfaces.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/CorgEng.Contents/ParentDestroyReaction.cs
+++ b/CorgEng.Contents/ParentDestroyReaction.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.Contents
+{
+    /// <summary>
+    /// The reaction to perform when a parent is destroyed.
+    /// </summary>
+    public enum ParentDestroyReaction
+    {
+        /// <summary>
+        /// Destroy all our contained children.
+        /// </summary>
+        DESTROY_CHILDREN,
+        /// <summary>
+        /// Move all the contained children to the current location of the deleted parent.
+        /// </summary>
+        DROP_CHILDREN,
+    }
+}

--- a/CorgEng.Contents/Systems/ContentsSystem.cs
+++ b/CorgEng.Contents/Systems/ContentsSystem.cs
@@ -1,0 +1,148 @@
+﻿using CorgEng.Contents.Components;
+using CorgEng.EntityComponentSystem.Events;
+using CorgEng.EntityComponentSystem.Events.Events;
+using CorgEng.EntityComponentSystem.Implementations.Deletion;
+using CorgEng.EntityComponentSystem.Implementations.Transform;
+using CorgEng.EntityComponentSystem.Systems;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.Contents.Systems
+{
+    internal class ContentsSystem : EntitySystem
+    {
+
+        /// <summary>
+        /// Function that creates a contents component, adds it to the parent and then returns the created component.
+        /// </summary>
+        private static Func<IEntity, ContentsComponent> CreateAndAddContentsFunction = (parent) =>
+        {
+            ContentsComponent createdComponent = new ContentsComponent();
+            parent.AddComponent(createdComponent);
+            return createdComponent;
+        };
+
+        public override EntitySystemFlags SystemFlags => EntitySystemFlags.HOST_SYSTEM;
+
+        public override void SystemSetup()
+        {
+            RegisterLocalEvent<ContainedComponent, DeleteEntityEvent>(OnContainedEntityDeleted);
+            RegisterLocalEvent<ContentsComponent, DeleteEntityEvent>(OnContentHolderDeleted);
+            RegisterLocalEvent<ContainedComponent, RemoveFromContentsEvent>(ExitContainer);
+            RegisterLocalEvent<DeleteableComponent, PutInsideContentsEvent>(EnterContainer);
+        }
+
+        /// <summary>
+        /// Causes an entity to exit its container
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="deleteableComponent"></param>
+        /// <param name="removeFromContentsEvent"></param>
+        private void ExitContainer(IEntity entity, ContainedComponent containedComponent, RemoveFromContentsEvent removeFromContentsEvent)
+        {
+            ContentsComponent parentContents = containedComponent.Parent.GetComponent<ContentsComponent>();
+            parentContents.EntitiesInContents.Remove(entity);
+            //Parent contains nothing, remove the contents component
+            if (parentContents.EntitiesInContents.Count == 0)
+            {
+                containedComponent.Parent.RemoveComponent(parentContents, false);
+            }
+            //Set the position of the thing that left the contents, if needed
+            TransformComponent? locatedTransform = containedComponent.Parent.FindComponent<TransformComponent>();
+            if (locatedTransform != null)
+            {
+                new SetPositionEvent(locatedTransform.Position).Raise(entity);
+            }
+            //Raise the left contents event
+            new ContentsChangedEvent(containedComponent.Parent, null).Raise(entity);
+        }
+
+        /// <summary>
+        /// Causes an entity to enter the container of another entity
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="deleteableComponent"></param>
+        /// <param name="putInsideContentsEvent"></param>
+        private void EnterContainer(IEntity entity, DeleteableComponent deleteableComponent, PutInsideContentsEvent putInsideContentsEvent)
+        {
+            //Check if we are stored inside something
+            ContainedComponent? containedComponent = entity.FindComponent<ContainedComponent>();
+            //We left the contents of an entity
+            if (containedComponent != null)
+            {
+                //Perform leaving actions
+                new ContentsChangedEvent(containedComponent.Parent, putInsideContentsEvent.NewHolder).Raise(entity);
+                //Set the contained component's parent
+                containedComponent.Parent = putInsideContentsEvent.NewHolder;
+            }
+            else
+            {
+                //Perform leaving actions
+                new ContentsChangedEvent(null, putInsideContentsEvent.NewHolder).Raise(entity);
+                //Add the contained component
+                containedComponent = new ContainedComponent(putInsideContentsEvent.NewHolder);
+                entity.AddComponent(containedComponent);
+            }
+            //If necessary, add a contents component to the parent
+            ContentsComponent parentContentsComponent = putInsideContentsEvent.NewHolder.FindComponent<ContentsComponent>()
+                ?? CreateAndAddContentsFunction.Invoke(putInsideContentsEvent.NewHolder);
+            //Add the entity to the container
+            parentContentsComponent.EntitiesInContents.Add(entity);
+        }
+
+        /// <summary>
+        /// When something stored inside another object is deleted.
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="containedComponent"></param>
+        /// <param name="deleteEntityEvent"></param>
+        private void OnContainedEntityDeleted(IEntity entity, ContainedComponent containedComponent, DeleteEntityEvent deleteEntityEvent)
+        {
+            ContentsComponent parentContents = containedComponent.Parent.GetComponent<ContentsComponent>();
+            parentContents.EntitiesInContents.Remove(entity);
+            //Parent contains nothing, remove the contents component
+            if (parentContents.EntitiesInContents.Count == 0)
+            {
+                containedComponent.Parent.RemoveComponent(parentContents, false);
+            }
+        }
+
+        /// <summary>
+        /// If an entity with children is deleted, all the children should be deleted too.
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <param name="contentsComponent"></param>
+        /// <param name="deleteEntityEvent"></param>
+        private void OnContentHolderDeleted(IEntity entity, ContentsComponent contentsComponent, DeleteEntityEvent deleteEntityEvent)
+        {
+            switch (contentsComponent.DestroyReaction)
+            {
+                case ParentDestroyReaction.DESTROY_CHILDREN:
+                    foreach (IEntity childEntity in contentsComponent.EntitiesInContents)
+                    {
+                        new DeleteEntityEvent().Raise(childEntity);
+                    }
+                    return;
+                case ParentDestroyReaction.DROP_CHILDREN:
+                    TransformComponent? parentTransform = entity.FindComponent<TransformComponent>();
+                    if (parentTransform != null)
+                    {
+                        //Leave the contents
+                        ContentsChangedEvent contentsExitedEvent = new ContentsChangedEvent(entity, null);
+                        //Set the new position to the dropped location
+                        foreach (IEntity childEntity in contentsComponent.EntitiesInContents)
+                        {
+                            contentsExitedEvent.Raise(childEntity);
+                        }
+                    }
+                    //Leave the contents
+                    return;
+            }
+        }
+
+    }
+}

--- a/CorgEng.Core/CorgEng.Core.sln
+++ b/CorgEng.Core/CorgEng.Core.sln
@@ -67,7 +67,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CorgEng.Pathfinding", "..\C
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CorgEng.Claims", "..\CorgEng.Claims\CorgEng.Claims.csproj", "{738F1392-2518-402E-B2BC-E2C531495F81}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CorgEng.IconSmoothing", "..\CorgEng.IconSmoothing\CorgEng.IconSmoothing.csproj", "{04742554-B547-4E2F-9D9E-0241CF2564FE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CorgEng.IconSmoothing", "..\CorgEng.IconSmoothing\CorgEng.IconSmoothing.csproj", "{04742554-B547-4E2F-9D9E-0241CF2564FE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CorgEng.Contents", "..\CorgEng.Contents\CorgEng.Contents.csproj", "{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -583,6 +585,26 @@ Global
 		{04742554-B547-4E2F-9D9E-0241CF2564FE}.Release|x64.Build.0 = Release|Any CPU
 		{04742554-B547-4E2F-9D9E-0241CF2564FE}.Release|x86.ActiveCfg = Release|Any CPU
 		{04742554-B547-4E2F-9D9E-0241CF2564FE}.Release|x86.Build.0 = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|ARM32.ActiveCfg = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|ARM32.Build.0 = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|x64.Build.0 = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Debug|x86.Build.0 = Debug|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|ARM32.ActiveCfg = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|ARM32.Build.0 = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|ARM64.Build.0 = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|x64.ActiveCfg = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|x64.Build.0 = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|x86.ActiveCfg = Release|Any CPU
+		{19B883CC-DB8C-47CF-B3EB-957ABEEB58FF}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CorgEng.EntityComponentSystem/Events/Events/ContentsChangedEvent.cs
+++ b/CorgEng.EntityComponentSystem/Events/Events/ContentsChangedEvent.cs
@@ -1,0 +1,52 @@
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Serialization;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.EntityComponentSystem.Events.Events
+{
+    /// <summary>
+    /// Called on an entity when it leaves another entities contents.
+    /// </summary>
+    public class ContentsChangedEvent : INetworkedEvent
+    {
+
+        [UsingDependency]
+        private static IAutoSerialiser AutoSerialiser = null!;
+
+        public bool CanBeRaisedByClient => false;
+
+        public IEntity OldHolder { get; }
+
+        public IEntity NewHolder { get; }
+
+        public ContentsChangedEvent(IEntity oldHolder, IEntity newHolder)
+        {
+            OldHolder = oldHolder;
+            NewHolder = newHolder;
+        }
+
+        public void Deserialise(BinaryReader reader)
+        {
+            throw new NotImplementedException("This method has not been implemented yet due to not figuring out " +
+                "what to do if an entity hasn't been recieved from the server yet, and networking beinga low priority at this time.");
+        }
+
+        public void Serialise(BinaryWriter writer)
+        {
+            AutoSerialiser.SerializeInto(typeof(uint?), OldHolder?.Identifier, writer);
+            AutoSerialiser.SerializeInto(typeof(uint?), NewHolder?.Identifier, writer);
+        }
+
+        public int SerialisedLength()
+        {
+            return AutoSerialiser.SerialisationLength(typeof(uint?), OldHolder?.Identifier)
+                + AutoSerialiser.SerialisationLength(typeof(uint?), NewHolder?.Identifier);
+        }
+    }
+}

--- a/CorgEng.EntityComponentSystem/Events/Events/PutInsideContentsEvent.cs
+++ b/CorgEng.EntityComponentSystem/Events/Events/PutInsideContentsEvent.cs
@@ -1,0 +1,24 @@
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.EntityComponentSystem.Events.Events
+{
+    /// <summary>
+    /// Called on a child to put it inside another entity.
+    /// </summary>
+    public class PutInsideContentsEvent : IEvent
+    {
+        public IEntity NewHolder { get; }
+
+        public PutInsideContentsEvent(IEntity holder)
+        {
+            NewHolder = holder;
+        }
+    }
+}

--- a/CorgEng.EntityComponentSystem/Events/Events/RemoveFromContentsEvent.cs
+++ b/CorgEng.EntityComponentSystem/Events/Events/RemoveFromContentsEvent.cs
@@ -1,0 +1,18 @@
+﻿using CorgEng.Core.Dependencies;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CorgEng.EntityComponentSystem.Events.Events
+{
+    /// <summary>
+    /// Called to make an entity leave its parent container
+    /// </summary>
+    public class RemoveFromContentsEvent : IEvent
+    {
+    }
+}

--- a/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderComponent.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderComponent.cs
@@ -41,6 +41,13 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
         [NetworkSerialized]
         public uint SpriteRendererIdentifier { get; set; }
 
+        /// <summary>
+        /// Is the sprite currently being rendered
+        /// </summary>
+        internal bool IsRendering { get; set; } = false;
+
+        internal bool WantsToRender { get; set; } = true;
+
         private uint cachedSpriteRendererIdentifier = 0;
 
         private ISpriteRenderer _spriteRenderer;


### PR DESCRIPTION
Creates the contents module, a module for handling putting entities inside other entities.
If an entity is put inside another entity then it stops rendering. Everything that is game specific will have to account for this, as the object does not get translated to another location and thus rendering and any other logic needs to be accounted for.