### PR TITLE
Content loading overlays, fixes dependency nodes failing if their first child is a comment

### DIFF
--- a/CorgEng.ContentLoading/DefinitionNodes/DependencyNode.cs
+++ b/CorgEng.ContentLoading/DefinitionNodes/DependencyNode.cs
@@ -64,16 +64,23 @@ namespace CorgEng.ContentLoading.DefinitionNodes
             isDynamic = new bool[node.ChildNodes.Count];
             for (int i = 0; i < node.ChildNodes.Count; i ++)
             {
-                //Parse the static value of the node
-                if (!(node.ChildNodes[i].FirstChild is XmlElement))
+                for (int j = 0; j < node.ChildNodes[i].ChildNodes.Count; j++)
                 {
-                    parameters[i] = TypeDescriptor.GetConverter(methodToCall.GetParameters()[i].ParameterType).ConvertFromString(node.ChildNodes[i].InnerText.Trim());
-                }
-                //Mark the node as dynamic
-                else
-                {
-                    hasDynamicParams = true;
-                    isDynamic[i] = true;
+                    //ignore comments
+                    if (node.ChildNodes[i].ChildNodes[j] is XmlComment)
+                        continue;
+                    //Parse the static value of the node
+                    if (!(node.ChildNodes[i].ChildNodes[j] is XmlElement))
+                    {
+                        parameters[i] = TypeDescriptor.GetConverter(methodToCall.GetParameters()[i].ParameterType).ConvertFromString(node.ChildNodes[i].InnerText.Trim());
+                    }
+                    //Mark the node as dynamic
+                    else
+                    {
+                        hasDynamicParams = true;
+                        isDynamic[i] = true;
+                    }
+                    break;
                 }
             }
         }

--- a/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderComponent.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderComponent.cs
@@ -31,6 +31,11 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
         public IIcon Sprite { get; set; }
 
         /// <summary>
+        /// The overlays to apply on boot
+        /// </summary>
+        public IIcon[] InitialOverlays { get; set; }
+
+        /// <summary>
         /// The render object that is drawing this component
         /// </summary>
         public ISpriteRenderObject SpriteRenderObject { get; internal set; }

--- a/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderSystem.cs
+++ b/CorgEng.EntityComponentSystem/Implementations/Rendering/SpriteRendering/SpriteRenderSystem.cs
@@ -6,6 +6,7 @@ using CorgEng.EntityComponentSystem.Implementations.Transform;
 using CorgEng.EntityComponentSystem.Systems;
 using CorgEng.GenericInterfaces.EntityComponentSystem;
 using CorgEng.GenericInterfaces.Logging;
+using CorgEng.GenericInterfaces.Rendering.Icons;
 using CorgEng.GenericInterfaces.Rendering.Renderers.SpriteRendering;
 using CorgEng.GenericInterfaces.Rendering.RenderObjects.SpriteRendering;
 using CorgEng.GenericInterfaces.Rendering.Textures;
@@ -61,6 +62,15 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
             spriteRenderComponent.CachedPosition = entity.GetComponent<TransformComponent>().Position.Copy();
             //Update the sprite
             UpdateSprite(spriteRenderComponent);
+            //Apply initial overlays
+            if (spriteRenderComponent.InitialOverlays != null)
+            {
+                foreach (IIcon overlay in spriteRenderComponent.InitialOverlays)
+                {
+                    spriteRenderComponent.SpriteRenderObject.AddOverlay(overlay);
+                }
+                spriteRenderComponent.InitialOverlays = null;
+            }
         }
 
         private void OnEntityDestroyed(IEntity entity, SpriteRenderComponent spriteRenderComponent, DeleteEntityEvent entityDeletedEvent)
@@ -78,6 +88,15 @@ namespace CorgEng.EntityComponentSystem.Implementations.Rendering.SpriteRenderin
             if (!CorgEngMain.IsRendering || spriteRenderComponent.Sprite == null)
                 return;
             UpdateSprite(spriteRenderComponent);
+            //Apply initial overlays
+            if (spriteRenderComponent.InitialOverlays != null)
+            {
+                foreach (IIcon overlay in spriteRenderComponent.InitialOverlays)
+                {
+                    spriteRenderComponent.SpriteRenderObject.AddOverlay(overlay);
+                }
+                spriteRenderComponent.InitialOverlays = null;
+            }
         }
 
         #endregion

--- a/CorgEng.Rendering/SpriteRendering/SpriteRenderObject.cs
+++ b/CorgEng.Rendering/SpriteRendering/SpriteRenderObject.cs
@@ -54,7 +54,32 @@ namespace CorgEng.Rendering.SpriteRendering
 
         public IBindableProperty<IVector<float>> CombinedTransformSecondRow { get; } = new BindableProperty<IVector<float>>(new Vector<float>(0, 1, 0));
 
-        public ISpriteRenderer CurrentRenderer { get; set; }
+        private ISpriteRenderer _currentRenderer;
+        public ISpriteRenderer CurrentRenderer
+        {
+            get => _currentRenderer;
+            set
+            {
+                //Stop rendering overlays
+                if (_currentRenderer != null)
+                {
+                    foreach (ISpriteRenderObject overlayObject in overlays.Values)
+                    {
+                        _currentRenderer.StopRendering(overlayObject);
+                    }
+                }
+                //Set the renderer
+                _currentRenderer = value;
+                //Move all overlays to the new renderer
+                if (_currentRenderer != null)
+                {
+                    foreach (ISpriteRenderObject overlayObject in overlays.Values)
+                    {
+                        _currentRenderer.StartRendering(overlayObject);
+                    }
+                }
+            }
+        }
 
         public ISpriteRenderObject Container { get; set; }
 
@@ -80,14 +105,16 @@ namespace CorgEng.Rendering.SpriteRendering
             //Set the layer
             IconLayer.Value[0] = layer;
             //When the vector changes, trigger change on the bindable property.
-            CombinedTransform.Value.OnChange += (object src, EventArgs arg) => {
+            CombinedTransform.Value.OnChange += (object src, EventArgs arg) =>
+            {
                 //Trigger a transform update
                 CombinedTransform.TriggerChanged();
             };
             //When the value of the combined transform is changed, we need to update our
             //rows, as they are bound to by the renderer which is where the updating needs
             //to be done.
-            CombinedTransform.ValueChanged += (object src, EventArgs arg) => {
+            CombinedTransform.ValueChanged += (object src, EventArgs arg) =>
+            {
                 //Trigger updates to our transform rows
                 CombinedTransformFirstRow.Value.X = CombinedTransform.Value[1, 1];
                 CombinedTransformFirstRow.Value.Y = CombinedTransform.Value[2, 1];
@@ -104,11 +131,13 @@ namespace CorgEng.Rendering.SpriteRendering
                 }
             };
             //When the self transform is updated, the combined transform needs to be updated too
-            SelfTransform.Value.OnChange += (object src, EventArgs arg) => {
+            SelfTransform.Value.OnChange += (object src, EventArgs arg) =>
+            {
                 SelfTransform.TriggerChanged();
             };
             //When the self transform is updated, calculate and apply our combined transform
-            SelfTransform.ValueChanged += (object src, EventArgs args) => {
+            SelfTransform.ValueChanged += (object src, EventArgs args) =>
+            {
                 CombinedTransform.Value = Container != null
                     ? Container.CombinedTransform.Value.Multiply(SelfTransform.Value)
                     : SelfTransform.Value;


### PR DESCRIPTION
Adds in the ability to add overlays to an entity inside the content loading files.
![image](https://user-images.githubusercontent.com/26465327/195701989-78892c53-1ae7-4f6e-99ad-28b03bd5bc44.png)
![image](https://user-images.githubusercontent.com/26465327/195702096-44abdda4-c31a-44b4-96ad-07aa8824e716.png)
(I know, these files are kind of getting bloaty but its a minor issue at the moment and probably won't be refactored.)