### PR TITLE
Fixes processing subsystems not handling synchronous events, fixes user interface depth testing

### DIFF
--- a/CorgEng.EntityComponentSystem/Systems/ProcessingSystem.cs
+++ b/CorgEng.EntityComponentSystem/Systems/ProcessingSystem.cs
@@ -51,6 +51,11 @@ namespace CorgEng.EntityComponentSystem.Systems
         /// </summary>
         public static double DeltaTimeMultiplier { get; set; } = 1;
 
+        private ConcurrentQueue<InvokationAction> WorkingQueue
+        {
+            get => priorityInvokationQueue.Count > 0 ? priorityInvokationQueue : invokationQueue;
+        }
+
         /// <summary>
         /// Override initial behaviour to also be able to handle processing at regular intervals
         /// </summary>
@@ -86,7 +91,7 @@ namespace CorgEng.EntityComponentSystem.Systems
                         Logger.WriteLine(e, LogType.ERROR);
                     }
                     //Check to see if a new signal that needs to be handled has come in
-                    if (invokationQueue.Count > 0)
+                    if (WorkingQueue.Count > 0)
                     {
                         //We have an invokation to handle, we will continue processing on the next cycle round
                         continued = true;
@@ -95,7 +100,7 @@ namespace CorgEng.EntityComponentSystem.Systems
                 }
                 //Allocate time to processing signal handles
                 InvokationAction current;
-                while (invokationQueue.TryDequeue(out current))
+                while (WorkingQueue.TryDequeue(out current))
                 {
                     try
                     {

--- a/CorgEng.UserInterface/UserInterfaceComponents/UserInterfaceComponent.cs
+++ b/CorgEng.UserInterface/UserInterfaceComponents/UserInterfaceComponent.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using static OpenGL.Gl;
 
 namespace CorgEng.UserInterface.Components
 {
@@ -154,7 +155,7 @@ namespace CorgEng.UserInterface.Components
         // Component Rendering Interfaces
         //====================================
 
-        private static void Render(UserInterfaceComponent userInterfaceComponent, uint buffer)
+        private static void Render(UserInterfaceComponent userInterfaceComponent, uint buffer, bool drawOnTop = false)
         {
             //Not initalized yet
             if (!userInterfaceComponent.initialized)
@@ -183,6 +184,10 @@ namespace CorgEng.UserInterface.Components
                     Render(childComponent as UserInterfaceComponent, userInterfaceComponent.FrameBufferUint);
                 }
             }
+            if (drawOnTop)
+            {
+                glEnable(GL_DEPTH_TEST);
+            }
             userInterfaceComponent.DrawToBuffer(
                 buffer,
                 (int)userInterfaceComponent.LeftOffset,
@@ -190,13 +195,17 @@ namespace CorgEng.UserInterface.Components
                 (int)userInterfaceComponent.PixelWidth,
                 (int)userInterfaceComponent.PixelHeight
             );
+            if (drawOnTop)
+            {
+                glDisable(GL_DEPTH_TEST);
+            }
         }
 
         public void DrawToFramebuffer(uint frameBuffer)
         {
             try
             {
-                Render(this, frameBuffer);
+                Render(this, frameBuffer, drawOnTop: true);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
fixes #120
Processing subsystems now actually handle things in their priority invokation queue, meaning that synchronous events will no longer freeze.
This also makes the user interface component render without depth testing, meaning it will render on top of everything if rendered last.