### PR TITLE
Fixes icon smoothing

### DIFF
--- a/CorgEng.IconSmoothing/Systems/SmoothIconSystem.cs
+++ b/CorgEng.IconSmoothing/Systems/SmoothIconSystem.cs
@@ -29,7 +29,7 @@ namespace CorgEng.IconSmoothing.Systems
 
         public override void SystemSetup()
         {
-            RegisterLocalEvent<SmoothIconComponent, ComponentAddedEvent>(OnEntityCreated);
+            RegisterLocalEvent<SmoothIconComponent, InitialiseEvent>(OnEntityCreated);
             RegisterLocalEvent<SmoothIconComponent, MoveEvent>(OnEntityMoved);
             RegisterLocalEvent<SmoothIconComponent, ComponentRemovedEvent>(OnComponentRemoved);
             RegisterLocalEvent<SmoothIconComponent, CalculateSmoothEvent>(SmoothEntity);
@@ -69,10 +69,8 @@ namespace CorgEng.IconSmoothing.Systems
         /// <param name="entity"></param>
         /// <param name="transformComponent"></param>
         /// <param name="componentAddedEvent"></param>
-        private void OnEntityCreated(IEntity entity, SmoothIconComponent trackComponent, ComponentAddedEvent componentAddedEvent)
+        private void OnEntityCreated(IEntity entity, SmoothIconComponent trackComponent, InitialiseEvent componentAddedEvent)
         {
-            if (componentAddedEvent.Component != trackComponent)
-                return;
             SmoothAround(trackComponent);
         }
 


### PR DESCRIPTION
Fixes icon smoothing failing to smooth. This was due to the transform being added after the the smooth icon component. Instead we use InitialiseEvent, which means all components are guaranteed to be added and the position is setup.

Initialisation was made for this, I just never added it.

![image](https://user-images.githubusercontent.com/26465327/196428955-52f3dcf9-4c37-4dd7-80b1-e191701aa542.png)
