### PR TITLE
Fixes entity system concurrency stalls and makes processing systems stop processing deleted entities

### DIFF
--- a/CorgEng.EntityComponentSystem/Components/Component.cs
+++ b/CorgEng.EntityComponentSystem/Components/Component.cs
@@ -18,7 +18,7 @@ namespace CorgEng.EntityComponentSystem.Components
     {
 
         [UsingDependency]
-        private static ILogger Logger;
+        private static ILogger Logger = null!;
         
         /// <summary>
         /// The parent of this component
@@ -29,6 +29,7 @@ namespace CorgEng.EntityComponentSystem.Components
 
         public virtual bool IsSynced { get; } = true;
 
+        //TODO: This is very memory expensive as its stored on ALL component instances, when it kind of works per-component.
         private List<InternalSignalHandleDelegate> componentInjectionLambdas = new List<InternalSignalHandleDelegate>();
 
         /// <summary>

--- a/CorgEng.EntityComponentSystem/Systems/EntitySystem.cs
+++ b/CorgEng.EntityComponentSystem/Systems/EntitySystem.cs
@@ -129,7 +129,11 @@ namespace CorgEng.EntityComponentSystem.Systems
                 if (invokationQueue.Count == 0 && priorityInvokationQueue.Count == 0)
                 {
                     isWaiting = true;
-                    waitHandle.WaitOne();
+                    //Protection from concurrency dangers
+                    if (invokationQueue.Count == 0 && priorityInvokationQueue.Count == 0)
+                    {
+                        waitHandle.WaitOne();
+                    }
                     isWaiting = false;
                 }
                 InvokationAction firstInvokation;


### PR DESCRIPTION
 - Subsystems could be frozen if the even entered while the subsystem was marked as not sleeping but actually sleeping (There is an extremely minor gap in these 2 things happening due to processors having a set speed). This has been fixed.
 - Subsystems will now stop processing when a component is removed from an entity.