### PR TITLE
Fixes multiple batches breaking on update

### DIFF
--- a/CorgEng.Tests/RenderingTests/BindedBatchTest.cs
+++ b/CorgEng.Tests/RenderingTests/BindedBatchTest.cs
@@ -207,5 +207,188 @@ namespace CorgEng.Tests.RenderingTests
 
         }
 
+        [TestMethod]
+        public void TestOverflowBatches()
+        {
+            //Create first property and add it
+            IBindableProperty<IVector<float>> property1 = new BindableProperty<IVector<float>>(new Vector<float>(1, 1, 1));
+            IBindableProperty<IVector<float>> property2 = new BindableProperty<IVector<float>>(new Vector<float>(1, 1));
+            IBindableProperty<IVector<float>> property3 = new BindableProperty<IVector<float>>(new Vector<float>(1));
+
+            TestBatch batch = new TestBatch(1);
+
+            IBatchElement<TestBatch> batchElement = new BatchElement<TestBatch>(
+                new IBindableProperty<IVector<float>>[] {
+                    property1,
+                    property2,
+                    property3,
+                });
+            batch.Add(batchElement);
+
+            //Test adding
+
+            Assert.AreEqual(0, batchElement.BatchPosition, "Expected 1st element in place 0.");
+            Assert.AreEqual(1, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[(batchElement.BatchPosition % batch.BatchSize) + 0], "Batch adding failure");
+            Assert.AreEqual(1, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[(batchElement.BatchPosition % batch.BatchSize) + 1], "Batch adding failure");
+            Assert.AreEqual(1, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[(batchElement.BatchPosition % batch.BatchSize) + 2], "Batch adding failure");
+            Assert.AreEqual(1, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[(batchElement.BatchPosition % batch.BatchSize) + 0], "Batch adding failure");
+            Assert.AreEqual(1, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[(batchElement.BatchPosition % batch.BatchSize) + 1], "Batch adding failure");
+            Assert.AreEqual(1, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 2)[(batchElement.BatchPosition % batch.BatchSize) + 0], "Batch adding failure");
+
+            //Test updating
+
+            property1.Value.X = 2;
+            property1.Value.Y = 2;
+            property1.Value.Z = 2;
+            property1.TriggerChanged();
+            property2.Value.X = 2;
+            property2.Value.Y = 2;
+            property2.TriggerChanged();
+            property3.Value.X = 2;
+            property3.TriggerChanged();
+
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Batch updating failure");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 1], "Batch updating failure");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 2], "Batch updating failure");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[2 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Batch updating failure");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[2 * (batchElement.BatchPosition % batch.BatchSize) + 1], "Batch updating failure");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 2)[1 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Batch updating failure");
+
+            //Add another element
+
+            IBindableProperty<IVector<float>> property12 = new BindableProperty<IVector<float>>(new Vector<float>(3, 3, 3));
+            IBindableProperty<IVector<float>> property22 = new BindableProperty<IVector<float>>(new Vector<float>(3, 3));
+            IBindableProperty<IVector<float>> property32 = new BindableProperty<IVector<float>>(new Vector<float>(3));
+            IBatchElement<TestBatch> batchElement2 = new BatchElement<TestBatch>(
+                new IBindableProperty<IVector<float>>[] {
+                    property12,
+                    property22,
+                    property32,
+                });
+            batch.Add(batchElement2);
+
+            //Test adding
+
+            Assert.AreEqual(1, batchElement2.BatchPosition, "Expected 2nd element in place 1.");
+            Assert.AreEqual(3, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch second add failure");
+            Assert.AreEqual(3, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Batch second add failure");
+            Assert.AreEqual(3, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 2], "Batch second add failure");
+            Assert.AreEqual(3, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch second add failure");
+            Assert.AreEqual(3, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Batch second add failure");
+            Assert.AreEqual(3, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 2)[1 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch second add failure");
+
+            //Test updating
+
+            property12.Value.X = 4;
+            property12.Value.Y = 4;
+            property12.Value.Z = 4;
+            property12.TriggerChanged();
+            property22.Value.X = 4;
+            property22.Value.Y = 4;
+            property22.TriggerChanged();
+            property32.Value.X = 4;
+            property32.TriggerChanged();
+
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch second update failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Batch second update failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 2], "Batch second update failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch second update failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Batch second update failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 2)[1 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch second update failure");
+
+            //Remove
+            batch.Remove(batchElement);
+
+            //Test
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch removal failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Batch removal failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 2], "Batch removal failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch removal failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Batch removal failure");
+            Assert.AreEqual(4, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 2)[1 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch removal failure");
+
+            //Test changing
+
+            property12.Value.X = 5;
+            property12.Value.Y = 5;
+            property12.Value.Z = 5;
+            property12.TriggerChanged();
+            property22.Value.X = 5;
+            property22.Value.Y = 5;
+            property22.TriggerChanged();
+            property32.Value.X = 5;
+            property32.TriggerChanged();
+
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch update post-removal failure");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Batch update post-removal failure");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 2], "Batch update post-removal failure");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch update post-removal failure");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Batch update post-removal failure");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 2)[1 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Batch update post-removal failure");
+
+            batch.Add(batchElement);
+
+            //Test adding
+
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A results in an incorrect batch configuration.");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 1], "Adding A, Adding B, Removing A, Adding A results in an incorrect batch configuration.");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 2], "Adding A, Adding B, Removing A, Adding A results in an incorrect batch configuration.");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[2 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A results in an incorrect batch configuration.");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[2 * (batchElement.BatchPosition % batch.BatchSize) + 1], "Adding A, Adding B, Removing A, Adding A results in an incorrect batch configuration.");
+            Assert.AreEqual(2, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 2)[1 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A results in an incorrect batch configuration.");
+
+            //Test updating
+
+            property1.Value.X = 6;
+            property1.Value.Y = 6;
+            property1.Value.Z = 6;
+            property1.TriggerChanged();
+            property2.Value.X = 6;
+            property2.Value.Y = 6;
+            property2.TriggerChanged();
+            property3.Value.X = 6;
+            property3.TriggerChanged();
+
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 1], "Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 2], "Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[2 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[2 * (batchElement.BatchPosition % batch.BatchSize) + 1], "Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 2)[1 * (batchElement.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 2], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+            Assert.AreEqual(5, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 2)[1 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating A results in an incorrect batch configuration");
+
+            //Test changing
+
+            property12.Value.X = 7;
+            property12.Value.Y = 7;
+            property12.Value.Z = 7;
+            property12.TriggerChanged();
+            property22.Value.X = 7;
+            property22.Value.Y = 7;
+            property22.TriggerChanged();
+            property32.Value.X = 7;
+            property32.TriggerChanged();
+
+            Assert.AreEqual(7, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(7, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(7, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 0)[3 * (batchElement2.BatchPosition % batch.BatchSize) + 2], "Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(7, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(7, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 1)[2 * (batchElement2.BatchPosition % batch.BatchSize) + 1], "Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(7, batch.GetArray(batchElement2.BatchPosition / batch.BatchSize, 2)[1 * (batchElement2.BatchPosition % batch.BatchSize) + 0], "Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 0], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 1], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 0)[3 * (batchElement.BatchPosition % batch.BatchSize) + 2], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[2 * (batchElement.BatchPosition % batch.BatchSize) + 0], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 1)[2 * (batchElement.BatchPosition % batch.BatchSize) + 1], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+            Assert.AreEqual(6, batch.GetArray(batchElement.BatchPosition / batch.BatchSize, 2)[1 * (batchElement.BatchPosition % batch.BatchSize) + 0], "(UNEXPECTED SIDE EFFECTS) Adding A, Adding B, Removing A, Adding A then updating B results in an incorrect batch configuration");
+
+
+        }
+
     }
 }

--- a/CorgEng.UtilityTypes/Batches/Batch.cs
+++ b/CorgEng.UtilityTypes/Batches/Batch.cs
@@ -11,7 +11,9 @@ namespace CorgEng.UtilityTypes.Batches
         where T : Batch<T>
     {
 
-        public const int DEFAULT_BATCH_SIZE = 25000;
+        public const int DEFAULT_BATCH_SIZE
+            = 25000;
+//          = 100;
 
         //Groupings of elements within this batch
         public abstract int[] BatchVectorSizes { get; }
@@ -172,7 +174,7 @@ namespace CorgEng.UtilityTypes.Batches
         /// </summary>
         private int GetArrayGroupIndex(int batchIndex, int groupIndex)
         {
-            return batchIndex / (BatchVectorSizes[groupIndex] * BatchSize);
+            return batchIndex / BatchSize;
         }
 
         public IEnumerator<IBatchElement<T>> GetEnumerator()


### PR DESCRIPTION
fixes #34 finally

You can now render an infinite number of things, this didn't work before due to a bug in batches which meant that updating batches with more than 1 element in the vector would update the wrong thing, causing things to render in the wrong places.

![image](https://user-images.githubusercontent.com/26465327/197335999-4aae2372-ca4a-4a1e-bf2e-9bb45f18aae6.png)
![image](https://user-images.githubusercontent.com/26465327/197336010-6eabd36c-bb52-443e-b53e-fd02271e0655.png)
![image](https://user-images.githubusercontent.com/26465327/197336016-4cdadd0b-fcde-436d-8764-0d0e38c3bcf1.png)

Keep going until you run out of memory