### PR TITLE
Fixes networking issue with communicating generic types

### DIFF
--- a/CorgEng.Example/CorgEngConfig.xml
+++ b/CorgEng.Example/CorgEngConfig.xml
@@ -9,6 +9,7 @@
     <Module>CorgEng.InputHandling</Module>
     <Module>CorgEng.Logging</Module>
     <Module>CorgEng.Networking</Module>
+    <Module>CorgEng.Pathfinding</Module>
     <Module>CorgEng.Rendering</Module>
     <Module>CorgEng.UtilityTypes</Module>
     <Module>CorgEng.UserInterface</Module>

--- a/CorgEng.Networking/Serialization/AutoSerialiser.cs
+++ b/CorgEng.Networking/Serialization/AutoSerialiser.cs
@@ -79,7 +79,7 @@ namespace CorgEng.Networking.Serialization
             }
             if (value is ICustomSerialisationBehaviour serialisationBehaviour)
             {
-                int genericSize = value.GetType().IsGenericType ? Marshal.SizeOf(value.GetType().GetGenericArguments()[0]) : 0;
+                int genericSize = value.GetType().IsGenericType ? sizeof(ushort) : 0;
                 return sizeof(ushort) + genericSize + serialisationBehaviour.GetSerialisationLength();
             }
             if (type.IsPrimitive)

--- a/CorgEng.Networking/VersionSync/VersionGenerator.cs
+++ b/CorgEng.Networking/VersionSync/VersionGenerator.cs
@@ -98,7 +98,8 @@ namespace CorgEng.Networking.VersionSync
         public static ushort GetNetworkedIdentifier(this IVersionSynced versionSyncedType)
         {
             ushort output;
-            networkedTypeIds.TryGetValue(versionSyncedType.GetType(), out output);
+            if (!networkedTypeIds.TryGetValue(versionSyncedType.GetType(), out output))
+                throw new Exception($"Failed to get networked identifier for version synced class {versionSyncedType.GetType()}.");
             return output;
         }
 

--- a/CorgEng.Rendering/Icons/Icon.cs
+++ b/CorgEng.Rendering/Icons/Icon.cs
@@ -66,13 +66,15 @@ namespace CorgEng.Rendering.Icons
             IconName = AutoSerialiser.Deserialize(typeof(string), binaryReader) as string;
             Layer = (float)AutoSerialiser.Deserialize(typeof(float), binaryReader);
             DirectionalState = (DirectionalState)AutoSerialiser.Deserialize(typeof(int), binaryReader);
+            Colour = (IVector<float>)AutoSerialiser.Deserialize(typeof(Vector<float>), binaryReader);
         }
 
         public int GetSerialisationLength()
         {
             return AutoSerialiser.SerialisationLength(typeof(string), IconName)
                 + AutoSerialiser.SerialisationLength(typeof(float), Layer)
-                + AutoSerialiser.SerialisationLength(typeof(int), (int)DirectionalState);
+                + AutoSerialiser.SerialisationLength(typeof(int), (int)DirectionalState)
+                + AutoSerialiser.SerialisationLength(typeof(Vector<float>), Colour);
         }
 
         public void SerialiseInto(BinaryWriter binaryWriter)
@@ -80,6 +82,7 @@ namespace CorgEng.Rendering.Icons
             AutoSerialiser.SerializeInto(typeof(string), IconName, binaryWriter);
             AutoSerialiser.SerializeInto(typeof(float), Layer, binaryWriter);
             AutoSerialiser.SerializeInto(typeof(int), (int)DirectionalState, binaryWriter);
+            AutoSerialiser.SerializeInto(typeof(Vector<float>), Colour, binaryWriter);
         }
 
     }

--- a/CorgEng.UtilityTypes/BindableProperties/BindableProperty.cs
+++ b/CorgEng.UtilityTypes/BindableProperties/BindableProperty.cs
@@ -11,6 +11,8 @@ namespace CorgEng.UtilityTypes.BindableProperties
         {
             get => _value;
             set {
+                if (value == null && typeof(T).GetGenericTypeDefinition() != typeof(Nullable<>))
+                    throw new ArgumentNullException("Attempting to set a bindable property of non-nullable type to null.");
                 _value = value;
                 TriggerChanged();
             }


### PR DESCRIPTION
Adds some more error detection and fixes an issue with communicating generic types.
This also adds pathfinding to the example, so that it loads the solidity module.
Bindable properties will also throw an error if an attempt to set them to null is made on a non-nullable type. (This comes from a networking deserialisation issue)