### PR TITLE
Enables vsync

### DIFF
--- a/CorgEng.Core/CorgEngMain.cs
+++ b/CorgEng.Core/CorgEngMain.cs
@@ -145,6 +145,8 @@ namespace CorgEng.Core
 #endif
             //Call the ready callbacks
             Ready();
+            //Use the FPS cap
+            Glfw.SwapInterval(1);
             //While the window shouldn't close
             while (!GameWindow.ShouldClose())
             {


### PR DESCRIPTION
Enables vsync in the renderer by setting the swap interval to 1 frame.
Without this the game will run as fast as the GPU lets it, which puts maximum load on the GPU. This causes my laptop to get pretty hot even if its great to see the game running at 350 FPS on an integrated GPU (Spare my battery life please).