### PR TITLE
Networking cleanup

### DIFF
--- a/CorgEng.GenericInterfaces/Networking/Clients/IClientAddress.cs
+++ b/CorgEng.GenericInterfaces/Networking/Clients/IClientAddress.cs
@@ -12,6 +12,8 @@ namespace CorgEng.GenericInterfaces.Networking.Clients
     public unsafe interface IClientAddress
     {
 
+        bool HasTargets { get; }
+
         byte[] ByteArray { get; }
 
         int AddressBytes { get; }

--- a/CorgEng.Networking/Clients/ClientAddress.cs
+++ b/CorgEng.Networking/Clients/ClientAddress.cs
@@ -16,6 +16,8 @@ namespace CorgEng.Networking.Clients
 
         public int AddressBytes { get; private set; }
 
+        public bool HasTargets => clients.Count > 0;
+
         private List<IClient> clients = new List<IClient>();
 
         public unsafe ClientAddress(int clientIndex, IClient client)

--- a/CorgEng.Networking/Networking/Client/NetworkingClient.cs
+++ b/CorgEng.Networking/Networking/Client/NetworkingClient.cs
@@ -61,6 +61,9 @@ namespace CorgEng.Networking.Networking.Client
         [UsingDependency]
         private static IPrototypeManager PrototypeManager;
 
+        [UsingDependency]
+        private static IQueuedPacketFactory QueuedPacketFactory = null!;
+
         public event ConnectionSuccess OnConnectionSuccess;
 
         public event ConnectionFailed OnConnectionFailed;
@@ -194,6 +197,8 @@ namespace CorgEng.Networking.Networking.Client
         public void QueueMessage(INetworkMessage message)
         {
             PacketQueue?.QueueMessage(null, message);
+            if (threadWaiting)
+                messageReadyWaitHandle.Set();
         }
 
         /// <summary>
@@ -358,8 +363,15 @@ namespace CorgEng.Networking.Networking.Client
         {
             //OnConnectionFailed = null;
             OnConnectionSuccess = null;
+            NetworkConfig.ProcessClientSystems = false;
+            if (!NetworkConfig.ProcessServerSystems)
+                NetworkConfig.NetworkingActive = false;
             base.Cleanup();
         }
 
+        protected override bool IsConnectedAddress(IPAddress address)
+        {
+            return this.address == address;
+        }
     }
 }

--- a/CorgEng.Networking/Networking/NetworkCommunicator.cs
+++ b/CorgEng.Networking/Networking/NetworkCommunicator.cs
@@ -121,6 +121,10 @@ namespace CorgEng.Networking.Networking
 
         public int TickRate { get; set; } = 32;
 
+#if DEBUG
+        private Random random = new Random();
+#endif
+
         /// <summary>
         /// The sender thread.
         /// Runs when it needs to, transmits data to the server
@@ -248,6 +252,13 @@ namespace CorgEng.Networking.Networking
                     return;
                 }
                 Logger.WriteMetric("packet_size", data.Length.ToString());
+#if DEBUG
+                // Simulated packet-loss
+                if (NetworkConfig.PacketDropProbability > 0 && random.Next() < NetworkConfig.PacketDropProbability)
+                {
+                    return;
+                }
+#endif
                 //Convert the packet into the individual messages
                 int messagePointer = 0;
                 while (messagePointer < data.Length)

--- a/CorgEng.Networking/Networking/NetworkCommunicator.cs
+++ b/CorgEng.Networking/Networking/NetworkCommunicator.cs
@@ -1,0 +1,306 @@
+﻿using CorgEng.Core;
+using CorgEng.Core.Dependencies;
+using CorgEng.Core.Modules;
+using CorgEng.DependencyInjection.Dependencies;
+using CorgEng.EntityComponentSystem.Entities;
+using CorgEng.EntityComponentSystem.Events;
+using CorgEng.EntityComponentSystem.Events.Events;
+using CorgEng.GenericInterfaces.EntityComponentSystem;
+using CorgEng.GenericInterfaces.Logging;
+using CorgEng.GenericInterfaces.Networking.Clients;
+using CorgEng.GenericInterfaces.Networking.Config;
+using CorgEng.GenericInterfaces.Networking.Networking;
+using CorgEng.GenericInterfaces.Networking.Networking.Client;
+using CorgEng.GenericInterfaces.Networking.Networking.Server;
+using CorgEng.GenericInterfaces.Networking.Packets;
+using CorgEng.GenericInterfaces.Networking.Packets.PacketQueues;
+using CorgEng.GenericInterfaces.Networking.PrototypeManager;
+using CorgEng.GenericInterfaces.Rendering;
+using CorgEng.Networking.Components;
+using CorgEng.Networking.EntitySystems;
+using CorgEng.Networking.Events;
+using CorgEng.Networking.Networking.Client;
+using CorgEng.Networking.Networking.Server;
+using CorgEng.Networking.VersionSync;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace CorgEng.Networking.Networking
+{
+    internal abstract class NetworkCommunicator
+    {
+
+        [UsingDependency]
+        private static ILogger Logger;
+
+        [UsingDependency]
+        private static INetworkMessageFactory NetworkMessageFactory;
+
+        [UsingDependency]
+        private static IPacketQueueFactory PacketQueueFactory;
+
+        [UsingDependency]
+        private static INetworkConfig NetworkConfig;
+
+        [UsingDependency]
+        private static IEntityCommunicator EntityCommunicator;
+
+        [UsingDependency]
+        private static IPrototypeManager PrototypeManager;
+
+        [UsingDependency]
+        private static IClientAddressingTableFactory ClientAddressingTableFactory;
+
+        [UsingDependency]
+        private static IEntityFactory EntityFactory;
+
+        public IClientAddressingTable ClientAddressingTable { get; private set; }
+
+        protected IPacketQueue PacketQueue;
+
+        public event NetworkMessageRecieved NetworkMessageReceived;
+
+        /// <summary>
+        /// The client that we are using to communicate
+        /// </summary>
+        protected UdpClient udpClient;
+
+        /// <summary>
+        /// The address we are connected to, if any
+        /// </summary>
+        protected IPAddress address;
+
+        /// <summary>
+        /// The port we are connected to
+        /// </summary>
+        protected int port;
+
+        /// <summary>
+        /// Are we connected to a server?
+        /// </summary>
+        protected bool connected;
+
+        /// <summary>
+        /// Are we connecting to a server?
+        /// </summary>
+        protected bool connecting;
+
+        /// <summary>
+        /// Are we running, or should we shutdown
+        /// </summary>
+        protected volatile bool running = false;
+
+        /// <summary>
+        /// The trigger that gets activated when shutdown is triggered
+        /// </summary>
+        protected readonly AutoResetEvent shutdownThreadTrigger = new AutoResetEvent(false);
+
+        /// <summary>
+        /// The countdown event that allows the shutdown method to wait until threads are shutdown.
+        /// </summary>
+        protected readonly CountdownEvent shutdownCountdown = new CountdownEvent(2);
+
+        /// <summary>
+        /// Have we ever been started?
+        /// </summary>
+        protected bool started = false;
+
+        /// <summary>
+        /// If this is true when shutdownThreadTrigger is raised, task will immediately end.
+        /// </summary>
+        protected bool cancelToken = false;
+
+        public int TickRate { get; set; } = 32;
+
+        /// <summary>
+        /// The sender thread.
+        /// Runs when it needs to, transmits data to the server
+        /// with a set tick rate.
+        /// </summary>
+        protected void NetworkSenderThread(UdpClient client)
+        {
+            Logger?.WriteLine($"{GetType().Name} sender for {address} thread successfull started.", LogType.DEBUG);
+            Stopwatch stopwatch = new Stopwatch();
+            double inverseTickrate = 1000.0 / TickRate;
+            while (running && (client.Client?.Connected ?? false))
+            {
+                try
+                {
+                    //Create a stopwatch to get the current time
+                    stopwatch.Restart();
+                    //Transmit packets
+                    while (PacketQueue.AcquireLockIfHasMessages())
+                    {
+                        try
+                        {
+                            //Dequeue the packet from the queue
+                            IQueuedPacket queuedPacket = PacketQueue.DequeuePacket();
+                            //Transmit the packet to the server
+                            byte[] data = queuedPacket.Data;
+                            //Asynchronously send the data
+                            //We send all the data straight to the server.
+                            //The client cannot communicate with other clients.
+                            udpClient.SendAsync(data, queuedPacket.TopPointer);
+                        }
+                        finally
+                        {
+                            PacketQueue.ReleaseLock();
+                        }
+                        //Logger.WriteLine($"Sent packets to the server", LogType.TEMP);
+                    }
+                    //Wait for variable time to maintain the tick rate
+                    stopwatch.Stop();
+                    double elapsedMilliseconds = stopwatch.ElapsedMilliseconds;
+                    double waitTime = inverseTickrate - elapsedMilliseconds;
+                    if (waitTime > 0)
+                    {
+                        //Sleep the thread
+                        shutdownThreadTrigger.WaitOne((int)waitTime);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger?.WriteLine(e, LogType.ERROR);
+                }
+            }
+            Logger?.WriteLine($"{GetType().Name} sender thread terminated", LogType.WARNING);
+            shutdownCountdown.Signal();
+        }
+
+        private ConcurrentQueue<(IPEndPoint, byte[])> packetQueue = new ConcurrentQueue<(IPEndPoint, byte[])>();
+
+        /// <summary>
+        /// The networking thread
+        /// </summary>
+        protected void NetworkListenerThread(UdpClient client)
+        {
+            Logger?.WriteLine($"{GetType().Name} listener for {address} thread successfull started.", LogType.DEBUG);
+            //Continue always
+            while (running && (client.Client?.Connected ?? false))
+            {
+                try
+                {
+                    //Wait until we are woken up
+                    IPEndPoint remoteEndPoint = new IPEndPoint(IPAddress.Any, port);
+                    byte[] incomingData = udpClient.Receive(ref remoteEndPoint);
+                    //Handle incomming data
+                    packetQueue.Enqueue((remoteEndPoint, incomingData));
+                }
+                catch (Exception e)
+                {
+                    Logger?.WriteLine(e, LogType.ERROR);
+                }
+            }
+            //Disconnected.
+            Logger?.WriteLine("Disconnected from remote server.", LogType.WARNING);
+            shutdownCountdown.Signal();
+        }
+
+        protected void ProcessQueueThread()
+        {
+            Logger?.WriteLine($"Packet queue processor thread started.", LogType.MESSAGE);
+            while (running)
+            {
+                //Nothing to process
+                if (packetQueue.Count == 0)
+                {
+                    Thread.Yield();
+                    continue;
+                }
+                //Stuff to do
+                try
+                {
+                    //Recieve messages
+                    (IPEndPoint, byte[]) packet;
+                    if (packetQueue.TryDequeue(out packet))
+                    {
+                        ProcessPacket(packet.Item1, packet.Item2);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Logger?.WriteLine($"Critical exception on processing thread: {e}", LogType.ERROR);
+                }
+            }
+            //Log shutdown
+            Logger?.WriteLine($"Packet queue processor thread stopped.", LogType.MESSAGE);
+        }
+
+        private void ProcessPacket(IPEndPoint sender, byte[] data)
+        {
+            try
+            {
+                //Ignore messages from people we weren't connecting to.
+                //All communications must go through the server.
+                //This is for security reasons, so a hacked client can't tell other players
+                //invalid information.
+                if (!sender.Address.Equals(address))
+                {
+                    return;
+                }
+                Logger.WriteMetric("packet_size", data.Length.ToString());
+                //Convert the packet into the individual messages
+                int messagePointer = 0;
+                while (messagePointer < data.Length)
+                {
+                    int originalPoint = messagePointer;
+                    //Read the integer (First 4 bytes is the size of the message)
+                    int packetSize = BitConverter.ToInt16(data, originalPoint);
+                    //Move the message pointer along
+                    messagePointer += packetSize + 0x06;
+                    //Read the packet header
+                    PacketHeaders packetHeader = (PacketHeaders)BitConverter.ToInt32(data, originalPoint + 0x02);
+                    //Get the data and pass it on
+                    HandleMessage(sender, packetHeader, data, originalPoint + 0x06, packetSize);
+                    // Invoke received message
+                    NetworkMessageReceived?.Invoke(packetHeader, data, originalPoint + 0x06, packetSize);
+                }
+            }
+            catch (Exception e)
+            {
+                Logger?.WriteLine(e, LogType.ERROR);
+            }
+        }
+
+        /// <summary>
+        /// Handle an incoming message
+        /// </summary>
+        protected abstract void HandleMessage(IPEndPoint sender, PacketHeaders header, byte[] data, int start, int length);
+
+        public virtual void Cleanup()
+        {
+            cancelToken = true;
+            Logger?.WriteLine($"{GetType().Name} cleanup called", LogType.LOG);
+            running = false;
+            shutdownThreadTrigger.Set();
+            udpClient?.Close();
+            udpClient?.Dispose();
+            udpClient = null;
+            connected = false;
+            connecting = false;
+            NetworkMessageReceived = null;
+            NetworkConfig.ProcessClientSystems = false;
+            if (!NetworkConfig.ProcessServerSystems)
+                NetworkConfig.NetworkingActive = false;
+            Logger?.WriteLine($"Waiting for {GetType().Name} cleanup completion...", LogType.LOG);
+            //Wait for the threads to be closed
+            if (started)
+                shutdownCountdown.Wait();
+            //Reset
+            shutdownThreadTrigger.Reset();
+            started = false;
+            cancelToken = false;
+            Logger?.WriteLine($"{GetType().Name} cleanup completed!", LogType.LOG);
+        }
+
+    }
+}

--- a/CorgEng.Networking/Networking/Server/NetworkingServer.cs
+++ b/CorgEng.Networking/Networking/Server/NetworkingServer.cs
@@ -80,10 +80,6 @@ namespace CorgEng.Networking.Networking.Server
 
         private double lastPingAt = 0;
 
-#if DEBUG
-        private Random random = new Random();
-#endif
-
         [ModuleLoad]
         public void LoadDefaultPrototype()
         {

--- a/CorgEng.Networking/Networking/Server/NetworkingServer.cs
+++ b/CorgEng.Networking/Networking/Server/NetworkingServer.cs
@@ -64,19 +64,12 @@ namespace CorgEng.Networking.Networking.Server
         [UsingDependency]
         private static IEntityFactory EntityFactory;
 
-        [UsingDependency]
-        private static IQueuedPacketFactory QueuedPacketFactory = null!;
-
         private static IPrototype DefaultEntityPrototype;
 
         /// <summary>
         /// A dictionary containing all connected clients
         /// </summary>
         internal Dictionary<IPAddress, IClient> connectedClients = new Dictionary<IPAddress, IClient>();
-
-        private volatile EventWaitHandle messageReadyWaitHandle = new EventWaitHandle(false, EventResetMode.AutoReset);
-
-        private volatile bool threadWaiting = false;
 
         private double lastPingAt = 0;
 
@@ -277,6 +270,22 @@ namespace CorgEng.Networking.Networking.Server
         public void SetClientPrototype(IPrototype prototype)
         {
             DefaultEntityPrototype = prototype ?? throw new ArgumentNullException(nameof(prototype));
+        }
+
+        public override void Cleanup()
+        {
+            connectedClients = new Dictionary<IPAddress, IClient>();
+            NetworkConfig.ProcessServerSystems = false;
+            if (!NetworkConfig.ProcessClientSystems)
+                NetworkConfig.NetworkingActive = false;
+            if (ServerCommunicator.server == this)
+                ServerCommunicator.server = null;
+            base.Cleanup();
+        }
+
+        protected override bool IsConnectedAddress(IPAddress address)
+        {
+            return connectedClients.ContainsKey(address);
         }
 
     }

--- a/CorgEng.Tests/Performance/ThreadTest.cs
+++ b/CorgEng.Tests/Performance/ThreadTest.cs
@@ -1,4 +1,4 @@
-﻿#define PERFORMANCE_TEST
+﻿//#define PERFORMANCE_TEST
 
 using CorgEng.Core.Dependencies;
 using CorgEng.GenericInterfaces.EntityComponentSystem;


### PR DESCRIPTION
This massively cleans up the networking code by putting the shared code of client and server into a single place.

Telling the server that we recieved a packet no longer goes through the queue system.

TODO:
- [ ] Reimplement ping
- [ ] Introduce packet drop handling